### PR TITLE
Fix issue where game ends prematurely when king is put in regular check

### DIFF
--- a/app/src/main/java/com/example/myapplication/GameViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/GameViewModel.kt
@@ -62,18 +62,31 @@ class GameViewModel(
             //  Would require filtering possibleMoves or rechecking after movement to see if
             //  the King moved into enemy range or an ally is no longer blocking enemy movement
 
-            // TODO [CLEANUP]: Move to a different function (called before allowing Player to select a move)
-            // If the current player is in Check,
-            if((_gameState.value.inCheckWhite && _gameState.value.turn == Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn == Set.BLACK)) {
-                println("Must escape check!")
-            }
-            // If the opposing player is in Check
-            if((_gameState.value.inCheckWhite && _gameState.value.turn != Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn != Set.BLACK)) {
-                println("The enemy is already in Check, game over! You win!")
-                // Current player wins
-                _gameState.value = _gameState.value.copy(
-                    winState = if(_gameState.value.turn == Set.WHITE) WinState.WHITE else WinState.BLACK
-                )
+//            // TODO [CLEANUP]: Move to a different function (called before allowing Player to select a move)
+//            // If the current player is in Check,
+//            if((_gameState.value.inCheckWhite && _gameState.value.turn == Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn == Set.BLACK)) {
+//                println("Must escape check!")
+//            }
+//            // If the opposing player is in Check
+//            if((_gameState.value.inCheckWhite && _gameState.value.turn != Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn != Set.BLACK)) {
+//                println("The enemy is already in Check, game over! You win!")
+//                // Current player wins
+//                _gameState.value = _gameState.value.copy(
+//                    winState = if(_gameState.value.turn == Set.WHITE) WinState.WHITE else WinState.BLACK
+//                )
+//                return
+//            }
+
+            val legalMoves = getLegalMoves(
+                allyPositions = _gameState.value.positionsWhite,
+                allyPieces = _gameState.value.piecesWhite,
+                enemyPositions = _gameState.value.positionsBlack,
+                enemyPieces = _gameState.value.piecesBlack
+            )
+
+            val isLegal = legalMoves.any { it.first == newPosition && it.second == selectedPieceIndex }
+            if (!isLegal) {
+                println("Move not allowed: puts king in check or invalid")
                 return
             }
 
@@ -168,17 +181,20 @@ class GameViewModel(
 
     // Move a Piece from the given (or current) Set with the given move selecting algorithm
     @VisibleForTesting
-    fun moveCPU(turn : Set = _gameState.value.turn,
-        pickMove : (enemyPositions : List<Pair<Int, Int>>,
-            enemyPieces : List<Piece>,
-            allyPositions : List<Pair<Int, Int>>,
-            allyPieces : List<Piece>) -> Pair<Pair<Int, Int>, Int>)
-    {
-        // Lock the UI buttons while an automatic turn is being taken
+    fun moveCPU(
+        turn: Set = _gameState.value.turn,
+        pickMove: (
+            enemyPositions: List<Pair<Int, Int>>,
+            enemyPieces: List<Piece>,
+            allyPositions: List<Pair<Int, Int>>,
+            allyPieces: List<Piece>
+        ) -> Pair<Pair<Int, Int>, Int>
+    ) {
+        // Lock UI
         _gameState.value = _gameState.value.copy(turn = turn, selectedSquare = INVALID_POSITION)
         _viewState.value = _viewState.value.copy(moveButtonLock = true)
 
-        // Depending on whose turn it is, different Ally and Enemy values are used
+        // Split sides
         val allyPositions: List<Pair<Int, Int>>
         val allyPieces: List<Piece>
         val enemyPositions: List<Pair<Int, Int>>
@@ -198,69 +214,138 @@ class GameViewModel(
             }
         }
 
-        // Cannot perform moves when there are no Pieces, return early
-        if(allyPieces.isEmpty() || _gameState.value.winState != WinState.NONE) {
-            return
-        }
-
-        // Check occurs if a King can be attacked by the enemy
-        // Checkmate occurs when there are no possible moves to escape Check
-        //  Would require filtering possibleMoves or rechecking after movement to see if
-        //  the King moved into enemy range or an ally is no longer blocking enemy movement
-
-        // If the current team is in Check,
-        if((_gameState.value.inCheckWhite && _gameState.value.turn == Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn == Set.BLACK)) {
-            println("Must escape check!")
-        }
-        // If the opposite team is in Check,
-        if((_gameState.value.inCheckWhite && _gameState.value.turn != Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn != Set.BLACK)) {
-            // Current team wins
+        if (allyPieces.none { it is King }) {
             _gameState.value = _gameState.value.copy(
-                winState = if(_gameState.value.turn == Set.WHITE) WinState.WHITE else WinState.BLACK)
-            return
-        }
-
-        // Pick a move using the given pickMove function
-        val positionIndexPair = pickMove(enemyPositions, enemyPieces, allyPositions, allyPieces)
-        val newPosition = positionIndexPair.first
-
-        // TODO [LOGIC ERROR]: Can put self in Check
-        // If the current team is in Check,
-        if((_gameState.value.inCheckWhite && _gameState.value.turn == Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn == Set.BLACK)) {
-            // Current team loses
-            _gameState.value = _gameState.value.copy(
-                winState = if(_gameState.value.turn == Set.BLACK) WinState.WHITE else WinState.BLACK)
-            return
-        }
-
-        // TODO [LOGIC]: Logic not implemented
-        // A Stalemate happens when neither player is in Check,
-        //  but all possible moves for the current player will put them in Check
-        // if(!inCheck && (possibleMove.filter { it.(doesn't put self in Check) } ).isEmpty())
-        if (newPosition == INVALID_POSITION) {
-            _gameState.value = _gameState.value.copy(
-                winState = WinState.STALEMATE
+                winState = if (turn == Set.WHITE) WinState.BLACK else WinState.WHITE
             )
             return
         }
 
-        // Update the game state, includes capturing of Pieces
+        // Skip if game ended or no pieces
+        if (allyPieces.isEmpty() || _gameState.value.winState != WinState.NONE) return
+
+        // Compute legal moves for the current side
+        val legalMoves = getLegalMoves(allyPositions, allyPieces, enemyPositions, enemyPieces)
+        if (legalMoves.isEmpty()) {
+            _gameState.value = _gameState.value.copy(winState = evaluateGameEnd())
+            return
+        }
+
+        // Ask the picker
+        val (newPosition, pieceIndex) = pickMove(enemyPositions, enemyPieces, allyPositions, allyPieces)
+
+        // Absolute safety guard
+        if (pieceIndex !in allyPieces.indices || newPosition == INVALID_POSITION) {
+            // No move chosen → just skip
+            return
+        }
+
+        // Only perform if the (position, index) pair is legal
+        val isLegal = legalMoves.any { it.first == newPosition && it.second == pieceIndex }
+        if (!isLegal) return
+
+        // Apply state
         _gameState.value = deriveNewGameState(
             newPosition = newPosition,
-            pieceIndex = positionIndexPair.second,
-            turn = _gameState.value.turn,
-            enemyPieces =  enemyPieces,
+            pieceIndex = pieceIndex,
+            turn = turn,
+            enemyPieces = enemyPieces,
             enemyPositions = enemyPositions,
             allyPositions = allyPositions,
             allyPieces = allyPieces
         )
 
-        // Update the animation state
+        // Animate safely using the validated index
         _animState.value = PieceAnimationState(
-            pieceToAnimate = allyPieces[positionIndexPair.second],
-            animatePositionStart = allyPositions[positionIndexPair.second],
-            animatePositionEnd = positionIndexPair.first
+            pieceToAnimate = allyPieces[pieceIndex],
+            animatePositionStart = allyPositions[pieceIndex],
+            animatePositionEnd = newPosition
         )
+    }
+
+    fun wouldBeInCheckAfterMove(
+        from: Pair<Int, Int>,
+        to: Pair<Int, Int>,
+        allyPositions: List<Pair<Int, Int>>,
+        allyPieces: List<Piece>,
+        enemyPositions: List<Pair<Int, Int>>,
+        enemyPieces: List<Piece>
+    ): Boolean {
+        val newAllyPositions = allyPositions.toMutableList()
+        val fromIndex = allyPositions.indexOf(from)
+        if (fromIndex == -1) return false // invalid move, ignore
+        newAllyPositions[fromIndex] = to
+
+        val kingIndex = allyPieces.indexOfFirst { it is King }
+        if (kingIndex == -1) {
+            return true
+        }
+
+        val kingPos = newAllyPositions[kingIndex]
+
+        for (i in enemyPieces.indices) {
+            val enemyMoves = enemyPieces[i].getValidMovesPositions(
+                enemyPositions[i],
+                newAllyPositions,
+                enemyPositions
+            )
+            if (kingPos in enemyMoves) return true
+        }
+        return false
+    }
+
+    fun getLegalMoves(
+        allyPositions: List<Pair<Int, Int>>,
+        allyPieces: List<Piece>,
+        enemyPositions: List<Pair<Int, Int>>,
+        enemyPieces: List<Piece>
+    ): List<Pair<Pair<Int, Int>, Int>> {
+
+        val legalMoves = mutableListOf<Pair<Pair<Int, Int>, Int>>()
+
+        for (i in allyPieces.indices) {
+            val piece = allyPieces[i]
+            val from = allyPositions[i]
+
+            val potentialMoves = piece.getValidMovesPositions(
+                position = from,
+                enemyPositions = enemyPositions,
+                allyPositions = allyPositions
+            )
+
+            for (to in potentialMoves) {
+                if (to.first !in 0 until BOARD_SIZE || to.second !in 0 until BOARD_SIZE) continue
+
+                if (allyPositions.contains(to)) continue
+
+                if (!wouldBeInCheckAfterMove(from, to, allyPositions, allyPieces, enemyPositions, enemyPieces)) {
+                    legalMoves.add(Pair(to, i))
+                }
+            }
+        }
+
+        return legalMoves
+    }
+
+    fun evaluateGameEnd(): WinState {
+        val state = _gameState.value
+        val currentTurn = state.turn
+
+        val allyPieces = if (currentTurn == Set.WHITE) state.piecesWhite else state.piecesBlack
+        val allyPositions = if (currentTurn == Set.WHITE) state.positionsWhite else state.positionsBlack
+        val enemyPieces = if (currentTurn == Set.WHITE) state.piecesBlack else state.piecesWhite
+        val enemyPositions = if (currentTurn == Set.WHITE) state.positionsBlack else state.positionsWhite
+
+        val inCheck = if (currentTurn == Set.WHITE) state.inCheckWhite else state.inCheckBlack
+        val legalMoves = getLegalMoves(allyPositions, allyPieces, enemyPositions, enemyPieces)
+
+        return when {
+            legalMoves.isNotEmpty() -> WinState.NONE
+            inCheck -> {
+                if (currentTurn == Set.WHITE) WinState.BLACK else WinState.WHITE
+            }
+            else -> WinState.STALEMATE
+        }
     }
 
     // Given game parameters, returns an updated version of the GameUIState
@@ -297,14 +382,42 @@ class GameViewModel(
         // Update Pieces and their positions (only the enemy team could have lost a Piece)
         mutableAllyPositions[pieceIndex] = newPosition
 
+//        // Update the inCheck status of both teams
+//        // Is the ally team inCheck?
+//        val allyKingIndex = allyPieces.indexOfFirst { it::class == King::class }
+//        val allyInCheck = checkCheck(mutableAllyPositions[allyKingIndex], mutableEnemyPositions, mutableEnemyPieces, mutableAllyPositions)
+//
+//        // Is the enemy team inCheck?
+//        val enemyKingIndex = mutableEnemyPieces.indexOfFirst { it::class == King::class }
+//        val enemyInCheck = checkCheck(mutableEnemyPositions[enemyKingIndex], mutableAllyPositions, allyPieces, mutableEnemyPositions)
+
         // Update the inCheck status of both teams
         // Is the ally team inCheck?
-        val allyKingIndex = allyPieces.indexOfFirst { it::class == King::class }
-        val allyInCheck = checkCheck(mutableAllyPositions[allyKingIndex], mutableEnemyPositions, mutableEnemyPieces, mutableAllyPositions)
+        val allyKingIndex = allyPieces.indexOfFirst { it is King }
+        val allyInCheck = if (allyKingIndex >= 0) {
+            checkCheck(
+                mutableAllyPositions[allyKingIndex],
+                mutableEnemyPositions,
+                mutableEnemyPieces,
+                mutableAllyPositions
+            )
+        } else {
+            // If the King is gone, that side has lost — not "in check"
+            false
+        }
 
         // Is the enemy team inCheck?
-        val enemyKingIndex = mutableEnemyPieces.indexOfFirst { it::class == King::class }
-        val enemyInCheck = checkCheck(mutableEnemyPositions[enemyKingIndex], mutableAllyPositions, allyPieces, mutableEnemyPositions)
+        val enemyKingIndex = mutableEnemyPieces.indexOfFirst { it is King }
+        val enemyInCheck = if (enemyKingIndex >= 0) {
+            checkCheck(
+                mutableEnemyPositions[enemyKingIndex],
+                mutableAllyPositions,
+                allyPieces,
+                mutableEnemyPositions
+            )
+        } else {
+            false
+        }
 
         // Next turn will be the opposite Set
         val nextTurn = when(_gameState.value.turn) {

--- a/app/src/main/java/com/example/myapplication/GameViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/GameViewModel.kt
@@ -62,32 +62,14 @@ class GameViewModel(
             //  Would require filtering possibleMoves or rechecking after movement to see if
             //  the King moved into enemy range or an ally is no longer blocking enemy movement
 
-//            // TODO [CLEANUP]: Move to a different function (called before allowing Player to select a move)
-//            // If the current player is in Check,
-//            if((_gameState.value.inCheckWhite && _gameState.value.turn == Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn == Set.BLACK)) {
-//                println("Must escape check!")
-//            }
-//            // If the opposing player is in Check
-//            if((_gameState.value.inCheckWhite && _gameState.value.turn != Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn != Set.BLACK)) {
-//                println("The enemy is already in Check, game over! You win!")
-//                // Current player wins
-//                _gameState.value = _gameState.value.copy(
-//                    winState = if(_gameState.value.turn == Set.WHITE) WinState.WHITE else WinState.BLACK
-//                )
-//                return
-//            }
-
-            val legalMoves = getLegalMoves(
-                allyPositions = _gameState.value.positionsWhite,
-                allyPieces = _gameState.value.piecesWhite,
-                enemyPositions = _gameState.value.positionsBlack,
-                enemyPieces = _gameState.value.piecesBlack
-            )
-
-            val isLegal = legalMoves.any { it.first == newPosition && it.second == selectedPieceIndex }
-            if (!isLegal) {
-                println("Move not allowed: puts king in check or invalid")
-                return
+            // TODO [CLEANUP]: Move to a different function (called before allowing Player to select a move)
+            // If the current player is in Check,
+            if((_gameState.value.inCheckWhite && _gameState.value.turn == Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn == Set.BLACK)) {
+                println("Must escape check!")
+            }
+            // If the opposite player is in Check, log it but do not end the game
+            if ((_gameState.value.inCheckWhite && _gameState.value.turn != Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn != Set.BLACK)) {
+                println("The enemy is in check")
             }
 
             // Otherwise, let the player take their turn,
@@ -181,20 +163,17 @@ class GameViewModel(
 
     // Move a Piece from the given (or current) Set with the given move selecting algorithm
     @VisibleForTesting
-    fun moveCPU(
-        turn: Set = _gameState.value.turn,
-        pickMove: (
-            enemyPositions: List<Pair<Int, Int>>,
-            enemyPieces: List<Piece>,
-            allyPositions: List<Pair<Int, Int>>,
-            allyPieces: List<Piece>
-        ) -> Pair<Pair<Int, Int>, Int>
-    ) {
-        // Lock UI
+    fun moveCPU(turn : Set = _gameState.value.turn,
+        pickMove : (enemyPositions : List<Pair<Int, Int>>,
+            enemyPieces : List<Piece>,
+            allyPositions : List<Pair<Int, Int>>,
+            allyPieces : List<Piece>) -> Pair<Pair<Int, Int>, Int>)
+    {
+        // Lock the UI buttons while an automatic turn is being taken
         _gameState.value = _gameState.value.copy(turn = turn, selectedSquare = INVALID_POSITION)
         _viewState.value = _viewState.value.copy(moveButtonLock = true)
 
-        // Split sides
+        // Depending on whose turn it is, different Ally and Enemy values are used
         val allyPositions: List<Pair<Int, Int>>
         val allyPieces: List<Piece>
         val enemyPositions: List<Pair<Int, Int>>
@@ -214,138 +193,63 @@ class GameViewModel(
             }
         }
 
-        if (allyPieces.none { it is King }) {
+        // Cannot perform moves when there are no Pieces, return early
+        if(allyPieces.isEmpty() || _gameState.value.winState != WinState.NONE) {
+            return
+        }
+
+        // Check occurs if a King can be attacked by the enemy
+        // Checkmate occurs when there are no possible moves to escape Check
+        //  Would require filtering possibleMoves or rechecking after movement to see if
+        //  the King moved into enemy range or an ally is no longer blocking enemy movement
+
+        // If the current team is in Check,
+        if((_gameState.value.inCheckWhite && _gameState.value.turn == Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn == Set.BLACK)) {
+            println("Must escape check!")
+        }
+        // If the opposite team is in Check, log it but do not end the game
+        if ((_gameState.value.inCheckWhite && _gameState.value.turn != Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn != Set.BLACK)) {
+            println("The enemy is in check")
+        }
+
+        // Pick a move using the given pickMove function
+        val positionIndexPair = pickMove(enemyPositions, enemyPieces, allyPositions, allyPieces)
+        val newPosition = positionIndexPair.first
+
+        // TODO [LOGIC ERROR]: Can put self in Check
+        // If the current team is in Check, log it but do not end the game
+        if((_gameState.value.inCheckWhite && _gameState.value.turn == Set.WHITE) || (_gameState.value.inCheckBlack && _gameState.value.turn == Set.BLACK)) {
+            println("Must escape check!")
+        }
+
+        // TODO [LOGIC]: Logic not implemented
+        // A Stalemate happens when neither player is in Check,
+        //  but all possible moves for the current player will put them in Check
+        // if(!inCheck && (possibleMove.filter { it.(doesn't put self in Check) } ).isEmpty())
+        if (newPosition == INVALID_POSITION) {
             _gameState.value = _gameState.value.copy(
-                winState = if (turn == Set.WHITE) WinState.BLACK else WinState.WHITE
+                winState = WinState.STALEMATE
             )
             return
         }
 
-        // Skip if game ended or no pieces
-        if (allyPieces.isEmpty() || _gameState.value.winState != WinState.NONE) return
-
-        // Compute legal moves for the current side
-        val legalMoves = getLegalMoves(allyPositions, allyPieces, enemyPositions, enemyPieces)
-        if (legalMoves.isEmpty()) {
-            _gameState.value = _gameState.value.copy(winState = evaluateGameEnd())
-            return
-        }
-
-        // Ask the picker
-        val (newPosition, pieceIndex) = pickMove(enemyPositions, enemyPieces, allyPositions, allyPieces)
-
-        // Absolute safety guard
-        if (pieceIndex !in allyPieces.indices || newPosition == INVALID_POSITION) {
-            // No move chosen → just skip
-            return
-        }
-
-        // Only perform if the (position, index) pair is legal
-        val isLegal = legalMoves.any { it.first == newPosition && it.second == pieceIndex }
-        if (!isLegal) return
-
-        // Apply state
+        // Update the game state, includes capturing of Pieces
         _gameState.value = deriveNewGameState(
             newPosition = newPosition,
-            pieceIndex = pieceIndex,
-            turn = turn,
-            enemyPieces = enemyPieces,
+            pieceIndex = positionIndexPair.second,
+            turn = _gameState.value.turn,
+            enemyPieces =  enemyPieces,
             enemyPositions = enemyPositions,
             allyPositions = allyPositions,
             allyPieces = allyPieces
         )
 
-        // Animate safely using the validated index
+        // Update the animation state
         _animState.value = PieceAnimationState(
-            pieceToAnimate = allyPieces[pieceIndex],
-            animatePositionStart = allyPositions[pieceIndex],
-            animatePositionEnd = newPosition
+            pieceToAnimate = allyPieces[positionIndexPair.second],
+            animatePositionStart = allyPositions[positionIndexPair.second],
+            animatePositionEnd = positionIndexPair.first
         )
-    }
-
-    fun wouldBeInCheckAfterMove(
-        from: Pair<Int, Int>,
-        to: Pair<Int, Int>,
-        allyPositions: List<Pair<Int, Int>>,
-        allyPieces: List<Piece>,
-        enemyPositions: List<Pair<Int, Int>>,
-        enemyPieces: List<Piece>
-    ): Boolean {
-        val newAllyPositions = allyPositions.toMutableList()
-        val fromIndex = allyPositions.indexOf(from)
-        if (fromIndex == -1) return false // invalid move, ignore
-        newAllyPositions[fromIndex] = to
-
-        val kingIndex = allyPieces.indexOfFirst { it is King }
-        if (kingIndex == -1) {
-            return true
-        }
-
-        val kingPos = newAllyPositions[kingIndex]
-
-        for (i in enemyPieces.indices) {
-            val enemyMoves = enemyPieces[i].getValidMovesPositions(
-                enemyPositions[i],
-                newAllyPositions,
-                enemyPositions
-            )
-            if (kingPos in enemyMoves) return true
-        }
-        return false
-    }
-
-    fun getLegalMoves(
-        allyPositions: List<Pair<Int, Int>>,
-        allyPieces: List<Piece>,
-        enemyPositions: List<Pair<Int, Int>>,
-        enemyPieces: List<Piece>
-    ): List<Pair<Pair<Int, Int>, Int>> {
-
-        val legalMoves = mutableListOf<Pair<Pair<Int, Int>, Int>>()
-
-        for (i in allyPieces.indices) {
-            val piece = allyPieces[i]
-            val from = allyPositions[i]
-
-            val potentialMoves = piece.getValidMovesPositions(
-                position = from,
-                enemyPositions = enemyPositions,
-                allyPositions = allyPositions
-            )
-
-            for (to in potentialMoves) {
-                if (to.first !in 0 until BOARD_SIZE || to.second !in 0 until BOARD_SIZE) continue
-
-                if (allyPositions.contains(to)) continue
-
-                if (!wouldBeInCheckAfterMove(from, to, allyPositions, allyPieces, enemyPositions, enemyPieces)) {
-                    legalMoves.add(Pair(to, i))
-                }
-            }
-        }
-
-        return legalMoves
-    }
-
-    fun evaluateGameEnd(): WinState {
-        val state = _gameState.value
-        val currentTurn = state.turn
-
-        val allyPieces = if (currentTurn == Set.WHITE) state.piecesWhite else state.piecesBlack
-        val allyPositions = if (currentTurn == Set.WHITE) state.positionsWhite else state.positionsBlack
-        val enemyPieces = if (currentTurn == Set.WHITE) state.piecesBlack else state.piecesWhite
-        val enemyPositions = if (currentTurn == Set.WHITE) state.positionsBlack else state.positionsWhite
-
-        val inCheck = if (currentTurn == Set.WHITE) state.inCheckWhite else state.inCheckBlack
-        val legalMoves = getLegalMoves(allyPositions, allyPieces, enemyPositions, enemyPieces)
-
-        return when {
-            legalMoves.isNotEmpty() -> WinState.NONE
-            inCheck -> {
-                if (currentTurn == Set.WHITE) WinState.BLACK else WinState.WHITE
-            }
-            else -> WinState.STALEMATE
-        }
     }
 
     // Given game parameters, returns an updated version of the GameUIState
@@ -382,42 +286,24 @@ class GameViewModel(
         // Update Pieces and their positions (only the enemy team could have lost a Piece)
         mutableAllyPositions[pieceIndex] = newPosition
 
-//        // Update the inCheck status of both teams
-//        // Is the ally team inCheck?
-//        val allyKingIndex = allyPieces.indexOfFirst { it::class == King::class }
-//        val allyInCheck = checkCheck(mutableAllyPositions[allyKingIndex], mutableEnemyPositions, mutableEnemyPieces, mutableAllyPositions)
-//
-//        // Is the enemy team inCheck?
-//        val enemyKingIndex = mutableEnemyPieces.indexOfFirst { it::class == King::class }
-//        val enemyInCheck = checkCheck(mutableEnemyPositions[enemyKingIndex], mutableAllyPositions, allyPieces, mutableEnemyPositions)
+        val allyKingIndex = allyPieces.indexOfFirst { it::class == King::class }
+        val enemyKingIndex = mutableEnemyPieces.indexOfFirst { it::class == King::class }
+
+        if (allyKingIndex == -1) {
+            val winner = if (turn == Set.WHITE) WinState.BLACK else WinState.WHITE
+            return _gameState.value.copy(winState = winner)
+        }
+        if (enemyKingIndex == -1) {
+            val winner = if (turn == Set.WHITE) WinState.WHITE else WinState.BLACK
+            return _gameState.value.copy(winState = winner)
+        }
 
         // Update the inCheck status of both teams
         // Is the ally team inCheck?
-        val allyKingIndex = allyPieces.indexOfFirst { it is King }
-        val allyInCheck = if (allyKingIndex >= 0) {
-            checkCheck(
-                mutableAllyPositions[allyKingIndex],
-                mutableEnemyPositions,
-                mutableEnemyPieces,
-                mutableAllyPositions
-            )
-        } else {
-            // If the King is gone, that side has lost — not "in check"
-            false
-        }
+        val allyInCheck = checkCheck(mutableAllyPositions[allyKingIndex], mutableEnemyPositions, mutableEnemyPieces, mutableAllyPositions)
 
         // Is the enemy team inCheck?
-        val enemyKingIndex = mutableEnemyPieces.indexOfFirst { it is King }
-        val enemyInCheck = if (enemyKingIndex >= 0) {
-            checkCheck(
-                mutableEnemyPositions[enemyKingIndex],
-                mutableAllyPositions,
-                allyPieces,
-                mutableEnemyPositions
-            )
-        } else {
-            false
-        }
+        val enemyInCheck = checkCheck(mutableEnemyPositions[enemyKingIndex], mutableAllyPositions, allyPieces, mutableEnemyPositions)
 
         // Next turn will be the opposite Set
         val nextTurn = when(_gameState.value.turn) {

--- a/app/src/test/java/com/example/myapplication/GameViewModelTest.kt
+++ b/app/src/test/java/com/example/myapplication/GameViewModelTest.kt
@@ -170,31 +170,69 @@ class GameViewModelTest {
     }
 
     @Test
-    fun `king in check does not immediately end the game`() {
-        val whiteKing = Pair(4, 4)
-        val whiteEscapeSquare = Pair(5, 4)
-        val blackRook = Pair(4, 7)
+    fun `black King in check does not immediately end the game after playerMove`() {
+        val blackKingPosition = Pair(0, 4)
+        val whiteRookPosition = Pair(4, 0)
+        val whiteKingPosition = Pair(7, 4)
 
         val initialState = GameUiState(
-            positionsWhite = listOf(whiteKing, whiteEscapeSquare),
-            positionsBlack = listOf(blackRook),
-            piecesWhite = listOf(King(Set.WHITE), Knight(Set.WHITE)),
-            piecesBlack = listOf(Rook(Set.BLACK)),
-            inCheckWhite = true,
-            inCheckBlack = false,
             turn = Set.WHITE,
+            piecesWhite = listOf(Rook(Set.WHITE), King(Set.WHITE)),
+            positionsWhite = listOf(whiteRookPosition, whiteKingPosition),
+            inCheckWhite = false,
+            piecesBlack = listOf(King(Set.BLACK)),
+            positionsBlack = listOf(blackKingPosition),
+            inCheckBlack = false,
             winState = WinState.NONE
         )
 
         val viewModel = GameViewModel(initialState)
 
-        viewModel.moveCPU(Set.WHITE) { enemyPositions, enemyPieces, allyPositions, allyPieces ->
-            Pair(INVALID_POSITION, 0) // dummy move
+        val newWhiteRookPosition = Pair(4, 4)
+
+        viewModel.playerMove(
+            selectedPieceIndex = 0,
+            newPosition = newWhiteRookPosition
+        )
+
+        val gameState = viewModel.gameState.value
+
+        assertTrue("Black should be in check after player move", gameState.inCheckBlack)
+        assertTrue("Game should continue after King is in check", gameState.winState == WinState.NONE)
+    }
+
+    @Test
+    fun `white King in check does not immediately end the game after moveCPU`() {
+        val whiteKingPosition = Pair(7, 4)
+        val blackBishopPosition = Pair(0, 5)
+        val blackKingPosition = Pair(0, 4)
+
+        val initialState = GameUiState(
+            turn = Set.WHITE,
+            piecesWhite = listOf(King(Set.WHITE)),
+            positionsWhite = listOf(whiteKingPosition),
+            inCheckWhite = false,
+            piecesBlack = listOf(Bishop(Set.BLACK), King(Set.BLACK)),
+            positionsBlack = listOf(blackBishopPosition, blackKingPosition),
+            inCheckBlack = false,
+            winState = WinState.NONE
+        )
+
+        val viewModel = GameViewModel(initialState)
+
+        val newBlackBishopPosition = Pair(4, 1)
+
+        viewModel.moveCPU(Set.BLACK) {
+            enemyPositions: List<Pair<Int, Int>>,
+            enemyPieces: List<Piece>,
+            allyPositions: List<Pair<Int, Int>>,
+            allyPieces: List<Piece> ->
+            Pair(newBlackBishopPosition, 0)
         }
 
-        assertTrue(
-            "Game should NOT be ended just because the King is in check",
-            WinState.NONE == viewModel.gameState.value.winState
-        )
+        val gameState = viewModel.gameState.value
+
+        assertTrue("White should be in check after CPU move", gameState.inCheckWhite)
+        assertTrue("Game should continue after King is in check", gameState.winState == WinState.NONE)
     }
 }

--- a/app/src/test/java/com/example/myapplication/GameViewModelTest.kt
+++ b/app/src/test/java/com/example/myapplication/GameViewModelTest.kt
@@ -168,4 +168,33 @@ class GameViewModelTest {
             !kingIsDead
         )
     }
+
+    @Test
+    fun `king in check does not immediately end the game`() {
+        val whiteKing = Pair(4, 4)
+        val whiteEscapeSquare = Pair(5, 4)
+        val blackRook = Pair(4, 7)
+
+        val initialState = GameUiState(
+            positionsWhite = listOf(whiteKing, whiteEscapeSquare),
+            positionsBlack = listOf(blackRook),
+            piecesWhite = listOf(King(Set.WHITE), Knight(Set.WHITE)),
+            piecesBlack = listOf(Rook(Set.BLACK)),
+            inCheckWhite = true,
+            inCheckBlack = false,
+            turn = Set.WHITE,
+            winState = WinState.NONE
+        )
+
+        val viewModel = GameViewModel(initialState)
+
+        viewModel.moveCPU(Set.WHITE) { enemyPositions, enemyPieces, allyPositions, allyPieces ->
+            Pair(INVALID_POSITION, 0) // dummy move
+        }
+
+        assertTrue(
+            "Game should NOT be ended just because the King is in check",
+            WinState.NONE == viewModel.gameState.value.winState
+        )
+    }
 }


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/ber4444/game/pull/15#issuecomment-3313782674) and updates the following:
- changed `playerMove()` and `moveCPU()` functions to not set the `winState` to either `WinState.BLACK` or `WinState.WHITE` if either team is put in regular check
- added 2 unit tests to validate that the game does not end when put in regular check after both `playerMove()` and `moveCPU()` are simulated