### PR TITLE
3D parity pass 2: desktop materials/bloom, web/iOS AA+bloom, de-band + iOS render fix

### DIFF
--- a/app/src/desktopMain/kotlin/com/example/myapplication/board3d/VulkanChessRenderer.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/board3d/VulkanChessRenderer.kt
@@ -72,8 +72,14 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
     private var uboParamsBuffer = VK_NULL_HANDLE; private var uboParamsMem = VK_NULL_HANDLE
     private val lightDir = org.joml.Vector3f(0.35f, 1.4f, -0.3f).normalize()  // higher sun, slightly behind the board
     // Look tunables — vkChess's exposure for papermill HDR is in this range; HIGH_QUALITY_WEBGPU uses 5.0.
-    private val exposure = 4.0f
+    private val exposure = 4.3f   // Pass-2: was 4.0 — warmer, less flat (Part A.4)
     private val gamma = 2.2f
+    // Part A look tunables (Pass-2 parity). These are baked as GLSL literals in FRAG_GLSL (constants,
+    // not animated) — kept here as the documented source of the chosen numbers. Eyeball via
+    // DesktopRendererSmokeTest (app/build/chess3d-*.png).
+    private val iblSpecularScale = 0.85f   // was a hard-coded 0.5 in FRAG_GLSL; restores gloss + board reflections
+    private val aoStrength = 1.0f          // how strongly mrTex.r (glTF occlusion) darkens the IBL ambient term
+    private val contactStrength = 0.35f    // how much the shadow factor (sh) deepens ambient at piece/board contact
 
     private val colorFormat = VK_FORMAT_R8G8B8A8_UNORM
     private val depthFormat = VK_FORMAT_D32_SFLOAT
@@ -296,7 +302,10 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
             matPush.putFloat(12, matSet.baseColorFactor.getOrElse(3) { 1f })
             matPush.putFloat(16, matSet.metallicFactor)
             matPush.putFloat(20, matSet.roughnessFactor)
-            matPush.putFloat(24, 0f); matPush.putFloat(28, 0f) // pad
+            // Part A.2: per-material roughness scale at the free pad slot (offset 24). Pieces get a
+            // tighter roughness (glossier, polished "wet" look); the marble board/frame stay at 1.0.
+            val roughScale = if (tex == ChessTexture.WHITE || tex == ChessTexture.BLACK) 0.8f else 1.0f
+            matPush.putFloat(24, roughScale); matPush.putFloat(28, 0f)
             vkCmdPushConstants(commandBuffer, pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, matPush)
             vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, stack.longs(ds), null)
             // Bind both vertex buffers (binding 0 = pos/normal/uv/tint, binding 1 = tangents).
@@ -1536,7 +1545,8 @@ layout(push_constant) uniform MaterialParams {
     vec4 baseColorFactor;
     float metallicFactor;
     float roughnessFactor;
-    vec2 pad;
+    float roughnessScale;   // Part A.2: per-material roughness multiplier (offset 24, was pad.x)
+    float pad;
 } mat;
 layout(location = 0) out vec4 outColor;
 
@@ -1632,10 +1642,11 @@ void main() {
     vec4 albedoTex = texture(tex, vUv);
     vec3 albedo = pow(albedoTex.rgb, vec3(2.2)) * mat.baseColorFactor.rgb * vTint;
 
-    // glTF spec: metallic = factor × tex.b; roughness = factor × tex.g (clamped to avoid mirror-sharp).
+    // glTF spec: metallic = factor × tex.b; roughness = factor × tex.g × per-material scale (Part A.2),
+    // clamped to avoid mirror-sharp. Piece MR has B pinned to 255 so metallic stays 0 for pieces.
     vec3 mr = texture(mrTex, vUv).rgb;
     float metallic = mat.metallicFactor * mr.b;
-    float roughness = clamp(mat.roughnessFactor * mr.g, 0.05, 1.0);
+    float roughness = clamp(mat.roughnessFactor * mr.g * mat.roughnessScale, 0.04, 1.0);
 
     // Apply tangent-space normal map (cracks/wear in the marble) to the geometric normal.
     vec3 N = normalize(perturbNormal(normalize(vNormal), vUv));
@@ -1662,13 +1673,21 @@ void main() {
     vec3 reflection = prefilteredReflection(R, roughness);
     vec2 brdf = texture(brdfLUT, vec2(max(dot(N, V), 0.0), roughness)).rg;
     vec3 F = F_SchlickR(max(dot(N, V), 0.0), F0, roughness);
-    // Scale down the IBL specular reflection — the papermill env is very bright and the default
-    // 1.0 scale washes out the warm wood albedo with neutral-white env reflections.
-    vec3 specular = reflection * (F * brdf.x + brdf.y) * 0.5;
+    // Part A.1 / A.3: IBL specular scale 0.5 -> 0.85 (iblSpecularScale). Restores gloss on pieces and
+    // the subtle board reflection that the halved scale muted. (mr.r occlusion + contact grounding
+    // applied below stop the brighter ambient from washing pieces out.)
+    vec3 specular = reflection * (F * brdf.x + brdf.y) * 0.85;
 
     vec3 kD = 1.0 - F;
     kD *= 1.0 - metallic;
     vec3 ambient = kD * diffuse + specular;
+
+    // Part A.3: glTF occlusion (mr.r) darkens only the indirect/ambient term. Piece MR.r is ~flat so
+    // this mostly grounds the marble board/frame; it is a no-op where mr.r == 1, so it is safe globally.
+    float ao = mr.r;
+    ambient *= mix(1.0, ao, 1.0);                          // aoStrength = 1.0
+    // Part A.3: deepen contact shadow on the ambient fill so pieces sit on the board instead of floating.
+    ambient *= mix(1.0 - 0.35, 1.0, sh);                   // contactStrength = 0.35
 
     vec3 color = ambient + Lo;
 

--- a/app/src/desktopMain/kotlin/com/example/myapplication/board3d/VulkanChessRenderer.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/board3d/VulkanChessRenderer.kt
@@ -323,17 +323,33 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
             val ds = textures[tex]?.descriptorSet ?: continue
             // Push per-material scalar factors (baseColorFactor + metallicFactor + roughnessFactor)
             // that modulate the albedo and MR textures in the fragment shader.
-            val matPush = stack.malloc(32)
+            val isPiece = tex == ChessTexture.WHITE || tex == ChessTexture.BLACK
+            // De-band: the piece albedo + MR textures bake very high-contrast horizontal wood grain,
+            // so on the lathe-turned geometry the pieces read as harsh rings. For pieces, soften the
+            // albedo grain toward the per-material mean wood colour and flatten roughness so the
+            // surface has an even sheen instead of alternating glossy/matte stripes. Board keeps its
+            // textured albedo/roughness. Mean wood colours measured from the glb whites/blacks albedo.
+            val meanR: Float; val meanG: Float; val meanB: Float
+            when (tex) {
+                ChessTexture.WHITE -> { meanR = 0.427f; meanG = 0.361f; meanB = 0.263f }
+                ChessTexture.BLACK -> { meanR = 0.176f; meanG = 0.114f; meanB = 0.075f }
+                else -> { meanR = 1f; meanG = 1f; meanB = 1f }
+            }
+            val grainStrength = if (isPiece) 0.5f else 1f       // keep 50% of the grain on pieces
+            val roughnessOverride = if (isPiece) 0.4f else 0f   // >0 = flat roughness; 0 = use texture
+            // Part A.2: per-material roughness scale at offset 24. Pieces glossier; board stays 1.0.
+            val roughScale = if (isPiece) 0.8f else 1.0f
+            val matPush = stack.malloc(48)
             matPush.putFloat(0, matSet.baseColorFactor.getOrElse(0) { 1f })
             matPush.putFloat(4, matSet.baseColorFactor.getOrElse(1) { 1f })
             matPush.putFloat(8, matSet.baseColorFactor.getOrElse(2) { 1f })
             matPush.putFloat(12, matSet.baseColorFactor.getOrElse(3) { 1f })
             matPush.putFloat(16, matSet.metallicFactor)
             matPush.putFloat(20, matSet.roughnessFactor)
-            // Part A.2: per-material roughness scale at the free pad slot (offset 24). Pieces get a
-            // tighter roughness (glossier, polished "wet" look); the marble board/frame stay at 1.0.
-            val roughScale = if (tex == ChessTexture.WHITE || tex == ChessTexture.BLACK) 0.8f else 1.0f
-            matPush.putFloat(24, roughScale); matPush.putFloat(28, 0f)
+            matPush.putFloat(24, roughScale)
+            matPush.putFloat(28, grainStrength)
+            matPush.putFloat(32, meanR); matPush.putFloat(36, meanG); matPush.putFloat(40, meanB)
+            matPush.putFloat(44, roughnessOverride)
             vkCmdPushConstants(commandBuffer, pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, matPush)
             vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, stack.longs(ds), null)
             // Bind both vertex buffers (binding 0 = pos/normal/uv/tint, binding 1 = tangents).
@@ -1124,7 +1140,7 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
 
         // Push constants: vec4 baseColorFactor (16B) + float metallicFactor + float roughnessFactor
         // + vec2 pad (16B) = 32 bytes per draw. Set per-material-group in recordCommandBuffer.
-        val matPushRange = VkPushConstantRange.calloc(1, stack).stageFlags(VK_SHADER_STAGE_FRAGMENT_BIT).offset(0).size(32)
+        val matPushRange = VkPushConstantRange.calloc(1, stack).stageFlags(VK_SHADER_STAGE_FRAGMENT_BIT).offset(0).size(48)
         val layoutInfo = VkPipelineLayoutCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO).pSetLayouts(stack.longs(descriptorSetLayout)).pPushConstantRanges(matPushRange)
         val pLayout = stack.mallocLong(1)
         check(vkCreatePipelineLayout(device, layoutInfo, null, pLayout) == VK_SUCCESS); pipelineLayout = pLayout.get(0)
@@ -1819,8 +1835,12 @@ layout(push_constant) uniform MaterialParams {
     vec4 baseColorFactor;
     float metallicFactor;
     float roughnessFactor;
-    float roughnessScale;   // Part A.2: per-material roughness multiplier (offset 24, was pad.x)
-    float pad;
+    float roughnessScale;     // 24: Part A.2 per-material roughness multiplier
+    float grainStrength;      // 28: de-band — 1 keeps full albedo grain; <1 pulls toward grainMean
+    float grainMeanR;         // 32
+    float grainMeanG;         // 36
+    float grainMeanB;         // 40: per-material mean wood colour (sRGB) the grain collapses toward
+    float roughnessOverride;  // 44: de-band — >0 uses this constant roughness instead of striped mr.g
 } mat;
 layout(location = 0) out vec4 outColor;
 
@@ -1914,13 +1934,22 @@ vec3 prefilteredReflection(vec3 R, float roughness) {
 void main() {
     // glTF spec: baseColor = factor × texture; sRGB→linear conversion of the albedo sample.
     vec4 albedoTex = texture(tex, vUv);
-    vec3 albedo = pow(albedoTex.rgb, vec3(2.2)) * mat.baseColorFactor.rgb * vTint;
+    vec3 albedoLin = pow(albedoTex.rgb, vec3(2.2));
+    // De-band: pull the (heavily striped) piece albedo toward the per-material mean wood colour so
+    // the baked grain reads as subtle texture, not hard rings. grainStrength == 1 is a no-op (board).
+    vec3 grainMeanLin = pow(vec3(mat.grainMeanR, mat.grainMeanG, mat.grainMeanB), vec3(2.2));
+    albedoLin = mix(grainMeanLin, albedoLin, mat.grainStrength);
+    vec3 albedo = albedoLin * mat.baseColorFactor.rgb * vTint;
 
     // glTF spec: metallic = factor × tex.b; roughness = factor × tex.g × per-material scale (Part A.2),
     // clamped to avoid mirror-sharp. Piece MR has B pinned to 255 so metallic stays 0 for pieces.
     vec3 mr = texture(mrTex, vUv).rgb;
     float metallic = mat.metallicFactor * mr.b;
-    float roughness = clamp(mat.roughnessFactor * mr.g * mat.roughnessScale, 0.04, 1.0);
+    // De-band: mr.g (roughness) is also striped, which alternates glossy/matte rings — the gloss boost
+    // amplified them. Pieces use a flat roughnessOverride for an even sheen; board keeps its texture.
+    float roughness = mat.roughnessOverride > 0.0
+        ? mat.roughnessOverride
+        : clamp(mat.roughnessFactor * mr.g * mat.roughnessScale, 0.04, 1.0);
 
     // Apply tangent-space normal map (cracks/wear in the marble) to the geometric normal.
     vec3 N = normalize(perturbNormal(normalize(vNormal), vUv));

--- a/app/src/desktopMain/kotlin/com/example/myapplication/board3d/VulkanChessRenderer.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/board3d/VulkanChessRenderer.kt
@@ -85,6 +85,17 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
     private val depthFormat = VK_FORMAT_D32_SFLOAT
     private val envFormat = VK_FORMAT_R16G16B16A16_SFLOAT
     private val brdfLutFormat = VK_FORMAT_R16G16_SFLOAT
+    // Part B: HDR scene resolve + bloom format. The scene pass now resolves into an RGBA16F target
+    // (linear HDR), and a post chain (bright -> blur -> composite) tonemaps in the final pass.
+    private val hdrFormat = VK_FORMAT_R16G16B16A16_SFLOAT
+
+    // Part B bloom tunables (env-overridable). CHESS_DESKTOP_BLOOM=0 keeps the HDR composite path
+    // but skips the bright/blur passes — i.e. reproduces the Part-A look (a one-line kill switch).
+    private val bloomEnabled = System.getenv("CHESS_DESKTOP_BLOOM")?.trim() != "0"
+    private val bloomThreshold = 1.1f   // HDR luma above which pixels start to bloom
+    private val bloomKnee = 0.5f        // soft-knee width below the threshold
+    private val bloomIntensity = 0.5f   // additive bloom strength in the composite pass
+    private val bloomIterations = 2     // number of H+V separable blur passes
 
     private var width = 0
     private var height = 0
@@ -92,6 +103,23 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
     private var colorImage = VK_NULL_HANDLE; private var colorMem = VK_NULL_HANDLE; private var colorView = VK_NULL_HANDLE // MSAA color
     private var depthImage = VK_NULL_HANDLE; private var depthMem = VK_NULL_HANDLE; private var depthView = VK_NULL_HANDLE // MSAA depth
     private var resolveImage = VK_NULL_HANDLE; private var resolveMem = VK_NULL_HANDLE; private var resolveView = VK_NULL_HANDLE // single-sample resolve (read back)
+    // Part B post pipeline. sceneHdr = HDR resolve of the scene pass (sampled by bloom + composite).
+    // resolveImage above is REPURPOSED as the composite (LDR) output that the readback copies — the
+    // names are kept to minimize churn, but its usage/role changed (see ensureTargets).
+    private var sceneHdrImage = VK_NULL_HANDLE; private var sceneHdrMem = VK_NULL_HANDLE; private var sceneHdrView = VK_NULL_HANDLE
+    private var bloomW = 0; private var bloomH = 0
+    private var bloomBright = VK_NULL_HANDLE; private var bloomBrightMem = VK_NULL_HANDLE; private var bloomBrightView = VK_NULL_HANDLE
+    private var bloomA = VK_NULL_HANDLE; private var bloomAMem = VK_NULL_HANDLE; private var bloomAView = VK_NULL_HANDLE
+    private var bloomB = VK_NULL_HANDLE; private var bloomBMem = VK_NULL_HANDLE; private var bloomBView = VK_NULL_HANDLE
+    private var postRenderPass = VK_NULL_HANDLE       // 1 hdr attachment, shared by bright + blur passes
+    private var compositeRenderPass = VK_NULL_HANDLE  // 1 ldr attachment (the read-back resolveImage)
+    private var postSetLayout = VK_NULL_HANDLE; private var postPool = VK_NULL_HANDLE
+    private var brightPipelineLayout = VK_NULL_HANDLE; private var brightPipeline = VK_NULL_HANDLE
+    private var blurPipelineLayout = VK_NULL_HANDLE; private var blurPipeline = VK_NULL_HANDLE
+    private var compositePipelineLayout = VK_NULL_HANDLE; private var compositePipeline = VK_NULL_HANDLE
+    private var brightFb = VK_NULL_HANDLE; private var aFb = VK_NULL_HANDLE; private var bFb = VK_NULL_HANDLE; private var compositeFb = VK_NULL_HANDLE
+    private var dsSceneHdr = VK_NULL_HANDLE; private var dsBright = VK_NULL_HANDLE
+    private var dsA = VK_NULL_HANDLE; private var dsB = VK_NULL_HANDLE; private var dsComposite = VK_NULL_HANDLE
     // Two env cubes (matching Android's Filament asset split, for natural colours + blurred bg):
     //  - skybox: papermill_skybox.ktx (R11F_G11F_B10F, 1 mip, blurred) — drawn behind everything.
     //  - ibl:    papermill_ibl.ktx    (R11F_G11F_B10F, 5 mip chain, already prefiltered by cmgen) —
@@ -319,6 +347,27 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
 
         vkCmdEndRenderPass(commandBuffer)
 
+        // --- Part B post chain (bright -> blur×N -> composite) tonemaps + writes the LDR result into
+        // resolveImage, which the trailing copy then reads back. With CHESS_DESKTOP_BLOOM=0 it's a
+        // composite-only pass (intensity 0) that reproduces the Part-A look over the HDR pipeline. ---
+        if (bloomEnabled) {
+            recordPostPass(stack, postRenderPass, brightFb, bloomW, bloomH, brightPipeline, brightPipelineLayout, dsSceneHdr,
+                floatArrayOf(bloomThreshold, bloomKnee, 0f, 0f))
+            for (i in 0 until bloomIterations) {
+                val blurSrc = if (i == 0) dsBright else dsB
+                val texelX = 1f / bloomW; val texelY = 1f / bloomH
+                recordPostPass(stack, postRenderPass, aFb, bloomW, bloomH, blurPipeline, blurPipelineLayout, blurSrc,
+                    floatArrayOf(texelX, texelY, 1f, 0f))
+                recordPostPass(stack, postRenderPass, bFb, bloomW, bloomH, blurPipeline, blurPipelineLayout, dsA,
+                    floatArrayOf(texelX, texelY, 0f, 1f))
+            }
+            recordPostPass(stack, compositeRenderPass, compositeFb, width, height, compositePipeline, compositePipelineLayout, dsComposite,
+                floatArrayOf(bloomIntensity, exposure, gamma, 0f))
+        } else {
+            recordPostPass(stack, compositeRenderPass, compositeFb, width, height, compositePipeline, compositePipelineLayout, dsComposite,
+                floatArrayOf(0f, exposure, gamma, 0f))
+        }
+
         val region = VkBufferImageCopy.calloc(1, stack)
         region.bufferOffset(0).bufferRowLength(0).bufferImageHeight(0)
         region.imageSubresource().aspectMask(VK_IMAGE_ASPECT_COLOR_BIT).mipLevel(0).baseArrayLayer(0).layerCount(1)
@@ -326,6 +375,27 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
         vkCmdCopyImageToBuffer(commandBuffer, resolveImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, readbackBuffer, region)
 
         check(vkEndCommandBuffer(commandBuffer) == VK_SUCCESS)
+    }
+
+    /** Records one fullscreen-triangle post pass (begin render pass, viewport/scissor, bind pipeline +
+     *  descriptor set, push the 4-float fragment constant, draw 3 verts, end). All post attachments
+     *  use loadOp DONT_CARE so no clear values are passed. */
+    private fun recordPostPass(stack: MemoryStack, rp: Long, fb: Long, w: Int, h: Int, pipe: Long, layout: Long, ds: Long, push: FloatArray) {
+        val area = VkRect2D.calloc(stack)
+        area.offset().set(0, 0); area.extent().set(w, h)
+        val begin = VkRenderPassBeginInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO).renderPass(rp).framebuffer(fb).renderArea(area)
+        vkCmdBeginRenderPass(commandBuffer, begin, VK_SUBPASS_CONTENTS_INLINE)
+        val vp = VkViewport.calloc(1, stack).x(0f).y(0f).width(w.toFloat()).height(h.toFloat()).minDepth(0f).maxDepth(1f)
+        vkCmdSetViewport(commandBuffer, 0, vp)
+        val sc = VkRect2D.calloc(1, stack); sc.get(0).offset().set(0, 0); sc.get(0).extent().set(w, h)
+        vkCmdSetScissor(commandBuffer, 0, sc)
+        vkCmdBindPipeline(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe)
+        vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, stack.longs(ds), null)
+        val pc = stack.malloc(16)
+        pc.putFloat(0, push[0]).putFloat(4, push[1]).putFloat(8, push[2]).putFloat(12, push[3])
+        vkCmdPushConstants(commandBuffer, layout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, pc)
+        vkCmdDraw(commandBuffer, 3, 1, 0, 0)
+        vkCmdEndRenderPass(commandBuffer)
     }
 
     private fun updateUbo(stack: MemoryStack, lightVP: Matrix4f) {
@@ -388,6 +458,10 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
             vkEnumeratePhysicalDevices(instance, count, devices)
             physicalDevice = VkPhysicalDevice(devices.get(0), instance)
             samples = getMaxUsableSampleCount(stack)
+            // Part B.0: the scene color target is now HDR (RGBA16F) AND multisampled AND sampled-from
+            // (after resolve). Clamp `samples` to whatever the device allows for hdrFormat as a
+            // multisampled COLOR_ATTACHMENT — MoltenVK supports 4×/8× RGBA16F, this guards weird drivers.
+            samples = samples and hdrColorSampleCounts(stack)
             queueFamily = findGraphicsQueueFamily(stack)
 
             val devExts = mutableListOf<String>()
@@ -430,6 +504,7 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
             createUboParamsBuffer(stack)
             createPipeline(stack)
             createSkyPipeline(stack)
+            createPostPipeline(stack)
         }
         // Load the papermill env cubes Android uses (skybox = blurred background, ibl = prefiltered
         // mip chain). Both fall back gracefully to "no env" if the asset is missing — the renderer
@@ -890,10 +965,21 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
         return VK_SAMPLE_COUNT_1_BIT
     }
 
+    /** Part B.0: sample counts supported by `hdrFormat` as a multisampled COLOR_ATTACHMENT (used to
+     *  clamp `samples` for the HDR scene target). Falls back to 1× if the query is unavailable. */
+    private fun hdrColorSampleCounts(stack: MemoryStack): Int {
+        val props = VkImageFormatProperties.calloc(stack)
+        val usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT
+        val r = vkGetPhysicalDeviceImageFormatProperties(physicalDevice, hdrFormat, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL, usage, 0, props)
+        if (r != VK_SUCCESS) return VK_SAMPLE_COUNT_1_BIT
+        return props.sampleCounts()
+    }
+
     private fun createRenderPass(stack: MemoryStack) {
-        // 0: MSAA color (rendered into), 1: MSAA depth, 2: single-sample resolve target (read back).
+        // 0: MSAA color (rendered into, HDR linear), 1: MSAA depth, 2: single-sample HDR resolve
+        // (sceneHdr — sampled by the bloom/composite passes, so finalLayout SHADER_READ_ONLY).
         val attachments = VkAttachmentDescription.calloc(3, stack)
-        attachments[0].format(colorFormat).samples(samples)
+        attachments[0].format(hdrFormat).samples(samples)
             .loadOp(VK_ATTACHMENT_LOAD_OP_CLEAR).storeOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
             .stencilLoadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE).stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
             .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED).finalLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
@@ -901,16 +987,23 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
             .loadOp(VK_ATTACHMENT_LOAD_OP_CLEAR).storeOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
             .stencilLoadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE).stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
             .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED).finalLayout(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-        attachments[2].format(colorFormat).samples(VK_SAMPLE_COUNT_1_BIT)
+        attachments[2].format(hdrFormat).samples(VK_SAMPLE_COUNT_1_BIT)
             .loadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE).storeOp(VK_ATTACHMENT_STORE_OP_STORE)
             .stencilLoadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE).stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
-            .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED).finalLayout(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
+            .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED).finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
         val colorRef = VkAttachmentReference.calloc(1, stack).attachment(0).layout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
         val depthRef = VkAttachmentReference.calloc(stack).attachment(1).layout(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
         val resolveRef = VkAttachmentReference.calloc(1, stack).attachment(2).layout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
         val subpass = VkSubpassDescription.calloc(1, stack).pipelineBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS)
             .colorAttachmentCount(1).pColorAttachments(colorRef).pResolveAttachments(resolveRef).pDepthStencilAttachment(depthRef)
-        val rpInfo = VkRenderPassCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO).pAttachments(attachments).pSubpasses(subpass)
+        // Part B: the bright/composite pass samples sceneHdr (attachment 2) right after this pass, so
+        // signal the src COLOR_ATTACHMENT_WRITE must complete before dst FRAGMENT_SHADER reads.
+        val dep = VkSubpassDependency.calloc(1, stack)
+            .srcSubpass(0).dstSubpass(VK_SUBPASS_EXTERNAL)
+            .srcStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT).dstStageMask(VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT)
+            .srcAccessMask(VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT).dstAccessMask(VK_ACCESS_SHADER_READ_BIT)
+            .dependencyFlags(VK_DEPENDENCY_BY_REGION_BIT)
+        val rpInfo = VkRenderPassCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO).pAttachments(attachments).pSubpasses(subpass).pDependencies(dep)
         val p = stack.mallocLong(1)
         check(vkCreateRenderPass(device, rpInfo, null, p) == VK_SUCCESS) { "vkCreateRenderPass failed" }
         renderPass = p.get(0)
@@ -1044,6 +1137,113 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
         check(vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, pipelineInfo, null, pPipeline) == VK_SUCCESS) { "pipeline failed" }
         pipeline = pPipeline.get(0)
         vkDestroyShaderModule(device, vert, null); vkDestroyShaderModule(device, frag, null)
+    }
+
+    /**
+     * Part B post pipeline: builds the two post render passes, a shared descriptor layout/pool, and
+     * the three fullscreen (FSQ_VERT) pipelines — bright (threshold HDR), blur (separable Gaussian),
+     * composite (scene + bloom, then tonemap+gamma into the LDR read-back target). All draws are a
+     * single `vkCmdDraw(3,1,0,0)` fullscreen triangle (no vertex buffers), mirroring buildBrdfLut.
+     */
+    private fun createPostPipeline(stack: MemoryStack) {
+        // postRenderPass: 1 HDR attachment, shared by the bright + blur passes. Two external
+        // dependencies (in/out) so consecutive bright/blur passes that read each other's output
+        // serialize correctly via layout transitions rather than manual barriers.
+        run {
+            val att = VkAttachmentDescription.calloc(1, stack)
+            att[0].format(hdrFormat).samples(VK_SAMPLE_COUNT_1_BIT)
+                .loadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE).storeOp(VK_ATTACHMENT_STORE_OP_STORE)
+                .stencilLoadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE).stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
+                .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED).finalLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+            val colorRef = VkAttachmentReference.calloc(1, stack).attachment(0).layout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+            val subpass = VkSubpassDescription.calloc(1, stack).pipelineBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS).colorAttachmentCount(1).pColorAttachments(colorRef)
+            val deps = VkSubpassDependency.calloc(2, stack)
+            deps[0].srcSubpass(VK_SUBPASS_EXTERNAL).dstSubpass(0)
+                .srcStageMask(VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT).dstStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
+                .srcAccessMask(VK_ACCESS_SHADER_READ_BIT).dstAccessMask(VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT)
+                .dependencyFlags(VK_DEPENDENCY_BY_REGION_BIT)
+            deps[1].srcSubpass(0).dstSubpass(VK_SUBPASS_EXTERNAL)
+                .srcStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT).dstStageMask(VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT)
+                .srcAccessMask(VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT).dstAccessMask(VK_ACCESS_SHADER_READ_BIT)
+                .dependencyFlags(VK_DEPENDENCY_BY_REGION_BIT)
+            val rpInfo = VkRenderPassCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO).pAttachments(att).pSubpasses(subpass).pDependencies(deps)
+            val p = stack.mallocLong(1)
+            check(vkCreateRenderPass(device, rpInfo, null, p) == VK_SUCCESS) { "postRenderPass failed" }
+            postRenderPass = p.get(0)
+        }
+        // compositeRenderPass: 1 LDR attachment (the read-back resolveImage), finalLayout TRANSFER_SRC
+        // so the trailing vkCmdCopyImageToBuffer is the natural next step. Out-dependency lands on
+        // the TRANSFER stage to order that copy.
+        run {
+            val att = VkAttachmentDescription.calloc(1, stack)
+            att[0].format(colorFormat).samples(VK_SAMPLE_COUNT_1_BIT)
+                .loadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE).storeOp(VK_ATTACHMENT_STORE_OP_STORE)
+                .stencilLoadOp(VK_ATTACHMENT_LOAD_OP_DONT_CARE).stencilStoreOp(VK_ATTACHMENT_STORE_OP_DONT_CARE)
+                .initialLayout(VK_IMAGE_LAYOUT_UNDEFINED).finalLayout(VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
+            val colorRef = VkAttachmentReference.calloc(1, stack).attachment(0).layout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
+            val subpass = VkSubpassDescription.calloc(1, stack).pipelineBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS).colorAttachmentCount(1).pColorAttachments(colorRef)
+            val deps = VkSubpassDependency.calloc(2, stack)
+            deps[0].srcSubpass(VK_SUBPASS_EXTERNAL).dstSubpass(0)
+                .srcStageMask(VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT).dstStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
+                .srcAccessMask(VK_ACCESS_SHADER_READ_BIT).dstAccessMask(VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT)
+                .dependencyFlags(VK_DEPENDENCY_BY_REGION_BIT)
+            deps[1].srcSubpass(0).dstSubpass(VK_SUBPASS_EXTERNAL)
+                .srcStageMask(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT).dstStageMask(VK_PIPELINE_STAGE_TRANSFER_BIT)
+                .srcAccessMask(VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT).dstAccessMask(VK_ACCESS_TRANSFER_READ_BIT)
+                .dependencyFlags(VK_DEPENDENCY_BY_REGION_BIT)
+            val rpInfo = VkRenderPassCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO).pAttachments(att).pSubpasses(subpass).pDependencies(deps)
+            val p = stack.mallocLong(1)
+            check(vkCreateRenderPass(device, rpInfo, null, p) == VK_SUCCESS) { "compositeRenderPass failed" }
+            compositeRenderPass = p.get(0)
+        }
+        // Descriptor layout (2 combined-image samplers, fragment stage) + pool for the 5 post sets.
+        val bindings = VkDescriptorSetLayoutBinding.calloc(2, stack)
+        for (i in 0..1) bindings[i].binding(i).descriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER).descriptorCount(1).stageFlags(VK_SHADER_STAGE_FRAGMENT_BIT)
+        val layoutInfo = VkDescriptorSetLayoutCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO).pBindings(bindings)
+        val pLayout = stack.mallocLong(1)
+        check(vkCreateDescriptorSetLayout(device, layoutInfo, null, pLayout) == VK_SUCCESS); postSetLayout = pLayout.get(0)
+        val poolSize = VkDescriptorPoolSize.calloc(1, stack).type(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER).descriptorCount(5 * 2)
+        val poolInfo = VkDescriptorPoolCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO).pPoolSizes(poolSize).maxSets(5)
+        val pPool = stack.mallocLong(1)
+        check(vkCreateDescriptorPool(device, poolInfo, null, pPool) == VK_SUCCESS); postPool = pPool.get(0)
+
+        val (brightLayout, brightPipe) = createFsqPipeline(stack, "brightFrag", BRIGHT_FRAG, postRenderPass)
+        brightPipelineLayout = brightLayout; brightPipeline = brightPipe
+        val (blurLayout, blurPipe) = createFsqPipeline(stack, "blurFrag", BLUR_FRAG, postRenderPass)
+        blurPipelineLayout = blurLayout; blurPipeline = blurPipe
+        val (compLayout, compPipe) = createFsqPipeline(stack, "compositeFrag", COMPOSITE_FRAG, compositeRenderPass)
+        compositePipelineLayout = compLayout; compositePipeline = compPipe
+    }
+
+    /** Builds one fullscreen-triangle pipeline (FSQ_VERT + [fragSrc]) over [renderPass] using the
+     *  shared [postSetLayout] + a 16-byte fragment push-constant range. Mirrors buildBrdfLut's setup. */
+    private fun createFsqPipeline(stack: MemoryStack, fragName: String, fragSrc: String, renderPass: Long): Pair<Long, Long> {
+        val vert = createShaderModule(stack, FSQ_VERT, Shaderc.shaderc_glsl_vertex_shader, fragName + "Vert")
+        val frag = createShaderModule(stack, fragSrc, Shaderc.shaderc_glsl_fragment_shader, fragName)
+        val stages = VkPipelineShaderStageCreateInfo.calloc(2, stack)
+        stages[0].sType(VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO).stage(VK_SHADER_STAGE_VERTEX_BIT).module(vert).pName(stack.UTF8("main"))
+        stages[1].sType(VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO).stage(VK_SHADER_STAGE_FRAGMENT_BIT).module(frag).pName(stack.UTF8("main"))
+        val vertexInput = VkPipelineVertexInputStateCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO)
+        val inputAssembly = VkPipelineInputAssemblyStateCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO).topology(VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST)
+        val viewportState = VkPipelineViewportStateCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO).viewportCount(1).scissorCount(1)
+        val raster = VkPipelineRasterizationStateCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO).polygonMode(VK_POLYGON_MODE_FILL).cullMode(VK_CULL_MODE_NONE).frontFace(VK_FRONT_FACE_COUNTER_CLOCKWISE).lineWidth(1f)
+        val multisample = VkPipelineMultisampleStateCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO).rasterizationSamples(VK_SAMPLE_COUNT_1_BIT)
+        val blendAttachment = VkPipelineColorBlendAttachmentState.calloc(1, stack).colorWriteMask(VK_COLOR_COMPONENT_R_BIT or VK_COLOR_COMPONENT_G_BIT or VK_COLOR_COMPONENT_B_BIT or VK_COLOR_COMPONENT_A_BIT).blendEnable(false)
+        val blend = VkPipelineColorBlendStateCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO).pAttachments(blendAttachment)
+        val dynamic = VkPipelineDynamicStateCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO).pDynamicStates(stack.ints(VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR))
+        val pushRange = VkPushConstantRange.calloc(1, stack).stageFlags(VK_SHADER_STAGE_FRAGMENT_BIT).offset(0).size(16)
+        val layoutInfo = VkPipelineLayoutCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO).pSetLayouts(stack.longs(postSetLayout)).pPushConstantRanges(pushRange)
+        val pLayout = stack.mallocLong(1)
+        check(vkCreatePipelineLayout(device, layoutInfo, null, pLayout) == VK_SUCCESS)
+        val layout = pLayout.get(0)
+        val pipelineInfo = VkGraphicsPipelineCreateInfo.calloc(1, stack).sType(VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO)
+            .pStages(stages).pVertexInputState(vertexInput).pInputAssemblyState(inputAssembly).pViewportState(viewportState)
+            .pRasterizationState(raster).pMultisampleState(multisample).pColorBlendState(blend).pDynamicState(dynamic)
+            .layout(layout).renderPass(renderPass).subpass(0)
+        val pPipe = stack.mallocLong(1)
+        check(vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, pipelineInfo, null, pPipe) == VK_SUCCESS) { "$fragName pipeline failed" }
+        vkDestroyShaderModule(device, vert, null); vkDestroyShaderModule(device, frag, null)
+        return layout to pPipe.get(0)
     }
 
     private fun createShaderModule(stack: MemoryStack, source: String, kind: Int, name: String): Long {
@@ -1262,20 +1462,70 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
         if (rw == width && rh == height && framebuffer != VK_NULL_HANDLE) return
         destroyTargets()
         width = rw; height = rh
-        val (ci, cm) = createImage(rw, rh, colorFormat, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT or VK_IMAGE_USAGE_TRANSFER_SRC_BIT, samples)
-        colorImage = ci; colorMem = cm; colorView = createImageView(colorImage, colorFormat, VK_IMAGE_ASPECT_COLOR_BIT)
+        // Scene MSAA color target is HDR (RGBA16F) — the scene pass writes linear HDR radiance now,
+        // resolved into sceneHdr for the post chain to sample. TRANSFER_SRC stays off (not read back).
+        val (ci, cm) = createImage(rw, rh, hdrFormat, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, samples)
+        colorImage = ci; colorMem = cm; colorView = createImageView(colorImage, hdrFormat, VK_IMAGE_ASPECT_COLOR_BIT)
         val (di, dm) = createImage(rw, rh, depthFormat, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, samples)
         depthImage = di; depthMem = dm; depthView = createImageView(depthImage, depthFormat, VK_IMAGE_ASPECT_DEPTH_BIT)
+        // HDR resolve of the scene pass (sampled by bright + composite).
+        val (si, sm) = createImage(rw, rh, hdrFormat, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT, VK_SAMPLE_COUNT_1_BIT)
+        sceneHdrImage = si; sceneHdrMem = sm; sceneHdrView = createImageView(sceneHdrImage, hdrFormat, VK_IMAGE_ASPECT_COLOR_BIT)
+        // resolveImage is now the composite's LDR output (the read-back target), no longer an MSAA resolve.
         val (ri, rm) = createImage(rw, rh, colorFormat, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT or VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_SAMPLE_COUNT_1_BIT)
         resolveImage = ri; resolveMem = rm; resolveView = createImageView(resolveImage, colorFormat, VK_IMAGE_ASPECT_COLOR_BIT)
+        // Half-res HDR ping-pong bloom targets.
+        bloomW = (rw / 2).coerceAtLeast(1); bloomH = (rh / 2).coerceAtLeast(1)
+        val bloomUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT
+        val (bri, brm) = createImage(bloomW, bloomH, hdrFormat, bloomUsage)
+        bloomBright = bri; bloomBrightMem = brm; bloomBrightView = createImageView(bloomBright, hdrFormat, VK_IMAGE_ASPECT_COLOR_BIT)
+        val (ai, am) = createImage(bloomW, bloomH, hdrFormat, bloomUsage)
+        bloomA = ai; bloomAMem = am; bloomAView = createImageView(bloomA, hdrFormat, VK_IMAGE_ASPECT_COLOR_BIT)
+        val (bi, bm) = createImage(bloomW, bloomH, hdrFormat, bloomUsage)
+        bloomB = bi; bloomBMem = bm; bloomBView = createImageView(bloomB, hdrFormat, VK_IMAGE_ASPECT_COLOR_BIT)
         MemoryStack.stackPush().use { stack ->
-            val fbInfo = VkFramebufferCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO).renderPass(renderPass).pAttachments(stack.longs(colorView, depthView, resolveView)).width(rw).height(rh).layers(1)
+            val sceneFbInfo = VkFramebufferCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO).renderPass(renderPass).pAttachments(stack.longs(colorView, depthView, sceneHdrView)).width(rw).height(rh).layers(1)
             val p = stack.mallocLong(1)
-            check(vkCreateFramebuffer(device, fbInfo, null, p) == VK_SUCCESS); framebuffer = p.get(0)
+            check(vkCreateFramebuffer(device, sceneFbInfo, null, p) == VK_SUCCESS); framebuffer = p.get(0)
+            val brightFbInfo = VkFramebufferCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO).renderPass(postRenderPass).pAttachments(stack.longs(bloomBrightView)).width(bloomW).height(bloomH).layers(1)
+            check(vkCreateFramebuffer(device, brightFbInfo, null, p) == VK_SUCCESS); brightFb = p.get(0)
+            val aFbInfo = VkFramebufferCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO).renderPass(postRenderPass).pAttachments(stack.longs(bloomAView)).width(bloomW).height(bloomH).layers(1)
+            check(vkCreateFramebuffer(device, aFbInfo, null, p) == VK_SUCCESS); aFb = p.get(0)
+            val bFbInfo = VkFramebufferCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO).renderPass(postRenderPass).pAttachments(stack.longs(bloomBView)).width(bloomW).height(bloomH).layers(1)
+            check(vkCreateFramebuffer(device, bFbInfo, null, p) == VK_SUCCESS); bFb = p.get(0)
+            val compFbInfo = VkFramebufferCreateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO).renderPass(compositeRenderPass).pAttachments(stack.longs(resolveView)).width(rw).height(rh).layers(1)
+            check(vkCreateFramebuffer(device, compFbInfo, null, p) == VK_SUCCESS); compositeFb = p.get(0)
+
+            // (Re)allocate the 5 post descriptor sets and wire them to the post targets via the shared
+            // linear/clamp brdfLutSampler (perfect for these single-mip targets). Resetting the pool
+            // frees the previous resize's sets in one call.
+            vkResetDescriptorPool(device, postPool, 0)
+            val counts = stack.ints(1, 1, 1, 1, 1)
+            val setLayouts = stack.longs(postSetLayout, postSetLayout, postSetLayout, postSetLayout, postSetLayout)
+            val allocInfo = VkDescriptorSetAllocateInfo.calloc(stack).sType(VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO).descriptorPool(postPool).pSetLayouts(setLayouts)
+            val pSets = stack.mallocLong(5)
+            check(vkAllocateDescriptorSets(device, allocInfo, pSets) == VK_SUCCESS)
+            dsSceneHdr = pSets.get(0); dsBright = pSets.get(1); dsA = pSets.get(2); dsB = pSets.get(3); dsComposite = pSets.get(4)
+            writePostDescriptor(stack, dsSceneHdr, sceneHdrView, sceneHdrView)
+            writePostDescriptor(stack, dsBright, bloomBrightView, bloomBrightView)
+            writePostDescriptor(stack, dsA, bloomAView, bloomAView)
+            writePostDescriptor(stack, dsB, bloomBView, bloomBView)
+            writePostDescriptor(stack, dsComposite, sceneHdrView, bloomBView)
         }
         readbackSize = (rw.toLong() * rh * 4)
         val (rb, rbm) = createBuffer(readbackSize, VK_BUFFER_USAGE_TRANSFER_DST_BIT, hostVisible)
         readbackBuffer = rb; readbackMem = rbm
+    }
+
+    /** Writes the two COMBINED_IMAGE_SAMPLER bindings of a post descriptor set (binding 0 = [view0],
+     *  binding 1 = [view1]) against the shared brdfLutSampler. */
+    private fun writePostDescriptor(stack: MemoryStack, set: Long, view0: Long, view1: Long) {
+        val info0 = VkDescriptorImageInfo.calloc(1, stack).imageLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL).imageView(view0).sampler(brdfLutSampler)
+        val info1 = VkDescriptorImageInfo.calloc(1, stack).imageLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL).imageView(view1).sampler(brdfLutSampler)
+        val writes = VkWriteDescriptorSet.calloc(2, stack)
+        writes[0].sType(VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET).dstSet(set).dstBinding(0).descriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER).descriptorCount(1).pImageInfo(info0)
+        writes[1].sType(VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET).dstSet(set).dstBinding(1).descriptorType(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER).descriptorCount(1).pImageInfo(info1)
+        vkUpdateDescriptorSets(device, writes, null)
     }
 
     private fun uploadGroup(tex: ChessTexture, group: SceneGroup) {
@@ -1403,16 +1653,28 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
     }
 
     private fun destroyTargets() {
-        if (framebuffer != VK_NULL_HANDLE) vkDestroyFramebuffer(device, framebuffer, null); framebuffer = VK_NULL_HANDLE
-        if (colorView != VK_NULL_HANDLE) vkDestroyImageView(device, colorView, null); colorView = VK_NULL_HANDLE
-        if (depthView != VK_NULL_HANDLE) vkDestroyImageView(device, depthView, null); depthView = VK_NULL_HANDLE
-        if (resolveView != VK_NULL_HANDLE) vkDestroyImageView(device, resolveView, null); resolveView = VK_NULL_HANDLE
-        if (colorImage != VK_NULL_HANDLE) vkDestroyImage(device, colorImage, null); colorImage = VK_NULL_HANDLE
-        if (depthImage != VK_NULL_HANDLE) vkDestroyImage(device, depthImage, null); depthImage = VK_NULL_HANDLE
-        if (resolveImage != VK_NULL_HANDLE) vkDestroyImage(device, resolveImage, null); resolveImage = VK_NULL_HANDLE
-        if (colorMem != VK_NULL_HANDLE) vkFreeMemory(device, colorMem, null); colorMem = VK_NULL_HANDLE
-        if (depthMem != VK_NULL_HANDLE) vkFreeMemory(device, depthMem, null); depthMem = VK_NULL_HANDLE
-        if (resolveMem != VK_NULL_HANDLE) vkFreeMemory(device, resolveMem, null); resolveMem = VK_NULL_HANDLE
+        // Post framebuffers first (they reference the views freed below). Descriptor sets are freed
+        // implicitly by resetting the pool on next allocate, so just null them here.
+        for (fb in longArrayOf(framebuffer, brightFb, aFb, bFb, compositeFb)) {
+            if (fb != VK_NULL_HANDLE) vkDestroyFramebuffer(device, fb, null)
+        }
+        framebuffer = VK_NULL_HANDLE; brightFb = VK_NULL_HANDLE; aFb = VK_NULL_HANDLE; bFb = VK_NULL_HANDLE; compositeFb = VK_NULL_HANDLE
+        dsSceneHdr = VK_NULL_HANDLE; dsBright = VK_NULL_HANDLE; dsA = VK_NULL_HANDLE; dsB = VK_NULL_HANDLE; dsComposite = VK_NULL_HANDLE
+        for (v in longArrayOf(sceneHdrView, bloomBrightView, bloomAView, bloomBView, colorView, depthView, resolveView)) {
+            if (v != VK_NULL_HANDLE) vkDestroyImageView(device, v, null)
+        }
+        sceneHdrView = VK_NULL_HANDLE; bloomBrightView = VK_NULL_HANDLE; bloomAView = VK_NULL_HANDLE; bloomBView = VK_NULL_HANDLE
+        colorView = VK_NULL_HANDLE; depthView = VK_NULL_HANDLE; resolveView = VK_NULL_HANDLE
+        for (img in longArrayOf(colorImage, depthImage, sceneHdrImage, resolveImage, bloomBright, bloomA, bloomB)) {
+            if (img != VK_NULL_HANDLE) vkDestroyImage(device, img, null)
+        }
+        colorImage = VK_NULL_HANDLE; depthImage = VK_NULL_HANDLE; sceneHdrImage = VK_NULL_HANDLE
+        resolveImage = VK_NULL_HANDLE; bloomBright = VK_NULL_HANDLE; bloomA = VK_NULL_HANDLE; bloomB = VK_NULL_HANDLE
+        for (mem in longArrayOf(colorMem, depthMem, sceneHdrMem, resolveMem, bloomBrightMem, bloomAMem, bloomBMem)) {
+            if (mem != VK_NULL_HANDLE) vkFreeMemory(device, mem, null)
+        }
+        colorMem = VK_NULL_HANDLE; depthMem = VK_NULL_HANDLE; sceneHdrMem = VK_NULL_HANDLE
+        resolveMem = VK_NULL_HANDLE; bloomBrightMem = VK_NULL_HANDLE; bloomAMem = VK_NULL_HANDLE; bloomBMem = VK_NULL_HANDLE
         if (readbackBuffer != VK_NULL_HANDLE) vkDestroyBuffer(device, readbackBuffer, null); readbackBuffer = VK_NULL_HANDLE
         if (readbackMem != VK_NULL_HANDLE) vkFreeMemory(device, readbackMem, null); readbackMem = VK_NULL_HANDLE
     }
@@ -1448,6 +1710,18 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
         if (brdfLutSampler != VK_NULL_HANDLE) vkDestroySampler(device, brdfLutSampler, null)
         if (descriptorPool != VK_NULL_HANDLE) vkDestroyDescriptorPool(device, descriptorPool, null)
         if (descriptorSetLayout != VK_NULL_HANDLE) vkDestroyDescriptorSetLayout(device, descriptorSetLayout, null)
+        // Part B post-pipeline teardown (pipelines/layouts/passes/pool; the per-frame post images +
+        // framebuffers are freed by destroyTargets above).
+        if (compositePipeline != VK_NULL_HANDLE) vkDestroyPipeline(device, compositePipeline, null)
+        if (blurPipeline != VK_NULL_HANDLE) vkDestroyPipeline(device, blurPipeline, null)
+        if (brightPipeline != VK_NULL_HANDLE) vkDestroyPipeline(device, brightPipeline, null)
+        if (compositePipelineLayout != VK_NULL_HANDLE) vkDestroyPipelineLayout(device, compositePipelineLayout, null)
+        if (blurPipelineLayout != VK_NULL_HANDLE) vkDestroyPipelineLayout(device, blurPipelineLayout, null)
+        if (brightPipelineLayout != VK_NULL_HANDLE) vkDestroyPipelineLayout(device, brightPipelineLayout, null)
+        if (postPool != VK_NULL_HANDLE) vkDestroyDescriptorPool(device, postPool, null)
+        if (postSetLayout != VK_NULL_HANDLE) vkDestroyDescriptorSetLayout(device, postSetLayout, null)
+        if (postRenderPass != VK_NULL_HANDLE) vkDestroyRenderPass(device, postRenderPass, null)
+        if (compositeRenderPass != VK_NULL_HANDLE) vkDestroyRenderPass(device, compositeRenderPass, null)
         destroyBuffer(uboBuffer, uboMem)
         destroyBuffer(uboParamsBuffer, uboParamsMem)
         if (brdfLutView != VK_NULL_HANDLE) vkDestroyImageView(device, brdfLutView, null)
@@ -1693,16 +1967,13 @@ void main() {
 
     // Selection-highlight glow: vTint > 1 emits extra light (used by the selection marker).
     vec3 glow = max(vTint - vec3(1.0), 0.0) * albedoTex.rgb * 1.6;
-    color += glow;
-
-    // Filmic tonemap + gamma. Clamp the tonemap input to avoid numerical explosions on hot pixels.
-    color = Uncharted2Tonemap(clamp(color * uboParams.exposure, 0.0, 256.0));
-    color = color * (1.0 / Uncharted2Tonemap(vec3(11.2)));
-    color = pow(color, vec3(1.0 / uboParams.gamma));
-
-    outColor = vec4(color, 1.0);
-}
-"""
+     color += glow;
+ 
+     // Part B.6: output raw linear HDR radiance. Tonemap + exposure + gamma moved to the composite
+     // pass so bloom can be extracted in HDR; the additive glow above will bloom (desirable).
+     outColor = vec4(color, 1.0);
+ }
+ """
 
         private const val SHADOW_VERT = """
 #version 450
@@ -1744,9 +2015,7 @@ vec3 Uncharted2Tonemap(vec3 x) {
 
 void main() {
     vec3 color = textureLod(envMap, normalize(vViewDir), 0.0).rgb;
-    color = Uncharted2Tonemap(clamp(color * uboParams.exposure, 0.0, 256.0));
-    color = color * (1.0 / Uncharted2Tonemap(vec3(11.2)));
-    color = pow(color, vec3(1.0 / uboParams.gamma));
+    // Part B.6: raw linear HDR sky radiance — tonemap happens in the composite pass.
     outColor = vec4(color, 1.0);
 }
 """
@@ -1943,6 +2212,70 @@ vec2 BRDF(float NoV, float roughness) {
 }
 void main() {
     outColor = vec4(BRDF(inUV.s, 1.0 - inUV.t), 0.0, 1.0);
+}
+"""
+
+        // Part B.7 — HDR bloom post shaders (drawn as fullscreen triangles via FSQ_VERT).
+
+        // BRIGHT_FRAG — threshold with a soft knee (Karis/UE style): below threshold+knee nothing
+        // passes; the soft quadratic knee eases in across [threshold-knee, threshold]; above the
+        // threshold everything passes at full strength.
+        private const val BRIGHT_FRAG = """
+#version 450
+layout(location = 0) in vec2 inUV;
+layout(set = 0, binding = 0) uniform sampler2D src;
+layout(push_constant) uniform PC { vec4 p; } pc; // p.x = threshold, p.y = knee
+layout(location = 0) out vec4 outColor;
+void main() {
+    vec3 c = texture(src, inUV).rgb;
+    float br = max(c.r, max(c.g, c.b));
+    float knee = max(pc.p.y, 1e-4);
+    float soft = clamp((br - pc.p.x + knee) / (2.0 * knee), 0.0, 1.0);
+    float w = max(soft * soft, step(pc.p.x, br));
+    outColor = vec4(c * w, 1.0);
+}
+"""
+
+        // BLUR_FRAG — separable 9-tap Gaussian. Push constant: xy = texel size, zw = direction
+        // (1,0)=horizontal or (0,1)=vertical. Run H then V, `bloomIterations` times.
+        private const val BLUR_FRAG = """
+#version 450
+layout(location = 0) in vec2 inUV;
+layout(set = 0, binding = 0) uniform sampler2D src;
+layout(push_constant) uniform PC { vec4 p; } pc;
+layout(location = 0) out vec4 outColor;
+const float W[5] = float[](0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
+void main() {
+    vec2 step = pc.p.xy * pc.p.zw;
+    vec3 c = texture(src, inUV).rgb * W[0];
+    for (int i = 1; i < 5; i++) {
+        c += texture(src, inUV + step * float(i)).rgb * W[i];
+        c += texture(src, inUV - step * float(i)).rgb * W[i];
+    }
+    outColor = vec4(c, 1.0);
+}
+"""
+
+        // COMPOSITE_FRAG — scene + bloom, then the single Uncharted2 tonemap + gamma (the only
+        // tonemap left now that the scene/sky shaders emit raw HDR). Push: x=intensity, y=exposure,
+        // z=gamma. With intensity 0 this is a straight tonemap of the HDR scene.
+        private const val COMPOSITE_FRAG = """
+#version 450
+layout(location = 0) in vec2 inUV;
+layout(set = 0, binding = 0) uniform sampler2D sceneHdr;
+layout(set = 0, binding = 1) uniform sampler2D bloomTex;
+layout(push_constant) uniform PC { vec4 p; } pc;
+layout(location = 0) out vec4 outColor;
+vec3 Uncharted2Tonemap(vec3 x) {
+    float A=0.15, B=0.50, C=0.10, D=0.20, E=0.02, F=0.30;
+    return ((x*(A*x+C*B)+D*E)/(x*(A*x+B)+D*F))-E/F;
+}
+void main() {
+    vec3 hdr = texture(sceneHdr, inUV).rgb + texture(bloomTex, inUV).rgb * pc.p.x;
+    vec3 col = Uncharted2Tonemap(clamp(hdr * pc.p.y, 0.0, 256.0));
+    col *= 1.0 / Uncharted2Tonemap(vec3(11.2));
+    col = pow(col, vec3(1.0 / pc.p.z));
+    outColor = vec4(col, 1.0);
 }
 """
     }

--- a/app/src/iosMain/kotlin/com/example/myapplication/board3d/IosBoard3D.kt
+++ b/app/src/iosMain/kotlin/com/example/myapplication/board3d/IosBoard3D.kt
@@ -12,6 +12,60 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGRectMake
 
+// Custom scheme the iOS board is served under so three.js can XHR the bundled glb/HDR assets
+// (file:// XHR is blocked by WKWebView). See BundleAssetSchemeHandler + WKWebViewChessRenderer.attach.
+internal const val ASSET_SCHEME = "chessasset"
+internal const val ASSET_HOST_URL = "chessasset://app/chess3d-host.html"
+
+/**
+ * Serves the app's bundled web assets (chess3d-host.html, chess3d-bundle.js, chess.glb,
+ * papermill_*.hdr) over [ASSET_SCHEME]. Unlike file://, a custom scheme is not blocked from
+ * XMLHttpRequest/fetch, so three.js's GLTFLoader/RGBELoader can load the model + environment.
+ */
+@OptIn(ExperimentalForeignApi::class)
+private class BundleAssetSchemeHandler : platform.darwin.NSObject(), platform.WebKit.WKURLSchemeHandlerProtocol {
+    @kotlinx.cinterop.ObjCSignatureOverride
+    override fun webView(webView: platform.WebKit.WKWebView, startURLSchemeTask: platform.WebKit.WKURLSchemeTaskProtocol) {
+        val url = startURLSchemeTask.request.URL
+        val data = url?.lastPathComponent?.let { loadBundleData(it) }
+        if (url == null || data == null) {
+            startURLSchemeTask.didFailWithError(platform.Foundation.NSError.errorWithDomain(ASSET_SCHEME, 404L, null))
+            return
+        }
+        val response = platform.Foundation.NSURLResponse(
+            uRL = url,
+            MIMEType = mimeForFile(url.lastPathComponent ?: ""),
+            expectedContentLength = data.length.toLong(),
+            textEncodingName = null,
+        )
+        runCatching {
+            startURLSchemeTask.didReceiveResponse(response)
+            startURLSchemeTask.didReceiveData(data)
+            startURLSchemeTask.didFinish()
+        }
+    }
+
+    @kotlinx.cinterop.ObjCSignatureOverride
+    override fun webView(webView: platform.WebKit.WKWebView, stopURLSchemeTask: platform.WebKit.WKURLSchemeTaskProtocol) {}
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun loadBundleData(fileName: String): platform.Foundation.NSData? {
+    val dot = fileName.lastIndexOf('.')
+    val name = if (dot >= 0) fileName.substring(0, dot) else fileName
+    val ext = if (dot >= 0) fileName.substring(dot + 1) else ""
+    val path = platform.Foundation.NSBundle.mainBundle.pathForResource(name, ofType = ext) ?: return null
+    return platform.Foundation.NSFileManager.defaultManager.contentsAtPath(path)
+}
+
+private fun mimeForFile(file: String): String = when {
+    file.endsWith(".html") -> "text/html"
+    file.endsWith(".js") -> "application/javascript"
+    file.endsWith(".glb") -> "model/gltf-binary"
+    file.endsWith(".hdr") -> "image/vnd.radiance"
+    else -> "application/octet-stream"
+}
+
 @OptIn(ExperimentalForeignApi::class)
 fun iosBoard3DSupport(): Board3DSupport {
     return Board3DSupport(
@@ -40,6 +94,13 @@ fun IosBoard3DSurface(renderer: Chess3DBoardRenderer, modifier: Modifier = Modif
     UIKitView(
         factory = {
             val config = platform.WebKit.WKWebViewConfiguration()
+            // WKWebView blocks XMLHttpRequest/fetch of file:// resources even when the page is loaded
+            // via loadFileURL(allowingReadAccessToURL:), so three.js's GLTFLoader/RGBELoader can't
+            // fetch chess.glb / papermill_*.hdr (they fail "Load failed" -> blank navy env-fallback).
+            // Serve the bundled assets through a custom URL scheme instead, which is not subject to
+            // that restriction. (The KVC `allowFileAccessFromFileURLs` pref is not exposed in
+            // Kotlin/Native, so a scheme handler is the workable fix.)
+            config.setURLSchemeHandler(BundleAssetSchemeHandler(), forURLScheme = ASSET_SCHEME)
             val view = platform.WebKit.WKWebView(frame = CGRectMake(0.0, 0.0, 1.0, 1.0), configuration = config)
             view.backgroundColor = platform.UIKit.UIColor.blackColor
             view.scrollView.scrollEnabled = false

--- a/app/src/iosMain/kotlin/com/example/myapplication/board3d/WKWebViewChessRenderer.kt
+++ b/app/src/iosMain/kotlin/com/example/myapplication/board3d/WKWebViewChessRenderer.kt
@@ -52,12 +52,12 @@ class WKWebViewChessRenderer : Chess3DBoardRenderer {
         val wkSurface = surface as? WkWebViewChess3DSurface ?: return
         webView = wkSurface.webView
 
-        // Load the host HTML from the app bundle via loadFileURL — the relative paths
-        // (./chess3d-bundle.js, ./chess.glb) resolve from the Resources directory.
-        val htmlPath = NSBundle.mainBundle.pathForResource("chess3d-host", "html") ?: return
-        val url = NSURL.fileURLWithPath(htmlPath)
-        val dir = url.URLByDeletingLastPathComponent!!
-        wkSurface.webView.loadFileURL(url, allowingReadAccessToURL = dir)
+        // Load the host HTML over the custom asset scheme (registered on the WKWebView config in
+        // IosBoard3D). The relative paths (./chess3d-bundle.js, ./chess.glb, ./papermill_*.hdr) then
+        // resolve to the same scheme and are served by BundleAssetSchemeHandler — three.js's
+        // loaders can XHR them, which a file:// origin blocks.
+        val url = NSURL.URLWithString(ASSET_HOST_URL) ?: return
+        wkSurface.webView.loadRequest(platform.Foundation.NSURLRequest(uRL = url))
 
         // Apply initial state after a delay (chess.glb load + three.js init takes ~2s).
         val initialFen = pendingFen

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/ThreeJsChessRenderer.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/ThreeJsChessRenderer.kt
@@ -213,9 +213,12 @@ const PIECE_SCALE = 0.5
 // detail — the main web regression was MSAA-only softness); SS_CAP bounds the fill-rate cost.
 const SS = 1.5            // render-buffer supersample factor (sharpness)
 const SS_CAP = 2.5        // hard cap on the effective pixel ratio
-const BLOOM_STRENGTH = 0.25
-const BLOOM_RADIUS = 0.4
-const BLOOM_THRESHOLD = 0.85
+// Bloom tuned to match Android's punchier warm halo: lower threshold so sunlit areas + specular
+// hotspots bloom, higher strength + wider radius for the dramatic "blown-out window" feel. The
+// papermill sun is warm, so its bloom reads warm without a separate tint.
+const BLOOM_STRENGTH = 0.7
+const BLOOM_RADIUS = 0.5
+const BLOOM_THRESHOLD = 0.6
 let composer, bloomPass, smaaPass   // alongside `renderer, scene, camera`
 let usePost = false                 // set true once the composer builds; falls back to bare render
 // Glb node names that are piece templates (kept at origin as geometry sources) or stray helpers

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/ThreeJsChessRenderer.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/ThreeJsChessRenderer.kt
@@ -213,12 +213,12 @@ const PIECE_SCALE = 0.5
 // detail — the main web regression was MSAA-only softness); SS_CAP bounds the fill-rate cost.
 const SS = 1.5            // render-buffer supersample factor (sharpness)
 const SS_CAP = 2.5        // hard cap on the effective pixel ratio
-// Bloom tuned to match Android's punchier warm halo: lower threshold so sunlit areas + specular
-// hotspots bloom, higher strength + wider radius for the dramatic "blown-out window" feel. The
-// papermill sun is warm, so its bloom reads warm without a separate tint.
-const BLOOM_STRENGTH = 0.7
-const BLOOM_RADIUS = 0.5
-const BLOOM_THRESHOLD = 0.6
+// Bloom tuned to a subtle Android-matching halo. The earlier punchy preset (strength 0.7 /
+// threshold 0.6) blew out the whole bright board centre; raise the threshold so only the brightest
+// specular/sun highlights bloom, and lower the strength so it reads as atmosphere, not glare.
+const BLOOM_STRENGTH = 0.35
+const BLOOM_RADIUS = 0.4
+const BLOOM_THRESHOLD = 0.85
 // De-band (mirrors the desktop Vulkan renderer): the glb whites/blacks albedo bakes high-contrast
 // horizontal wood grain and the shared metallicRoughness map's green channel is striped too, so on
 // the lathe-turned pieces both wrap into hard rings. We soften the albedo grain toward the per-

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/ThreeJsChessRenderer.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/ThreeJsChessRenderer.kt
@@ -196,12 +196,28 @@ import * as THREE from 'three'
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js'
 import { RGBELoader } from 'three/addons/loaders/RGBELoader.js'
 import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js'
+// Part C: EffectComposer supplies both crisper AA (HalfFloat MSAA render target + supersample +
+// SMAA) and bloom. Pinned to three@0.169.0 via the import map (web) / esbuild (iOS bundle).
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js'
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js'
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
+import { SMAAPass } from 'three/addons/postprocessing/SMAAPass.js'
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js'
 
 // The board lives in the game's ±4 space (1-unit squares). chess.glb is authored at ±8 with
 // 2-unit squares, so every glb node is scaled by 0.5 — matching Android's scale=0.5 exactly.
 // Piece world coordinates now arrive already in this ±4 space from Kotlin (Board3DScene/BoardGeometry
 // via chess3d.setScene), including the animated y (move arc hop + selection bounce).
 const PIECE_SCALE = 0.5
+// Part C AA + bloom tunables. SS supersamples the render buffer (sharper silhouettes / sculpt
+// detail — the main web regression was MSAA-only softness); SS_CAP bounds the fill-rate cost.
+const SS = 1.5            // render-buffer supersample factor (sharpness)
+const SS_CAP = 2.5        // hard cap on the effective pixel ratio
+const BLOOM_STRENGTH = 0.25
+const BLOOM_RADIUS = 0.4
+const BLOOM_THRESHOLD = 0.85
+let composer, bloomPass, smaaPass   // alongside `renderer, scene, camera`
+let usePost = false                 // set true once the composer builds; falls back to bare render
 // Glb node names that are piece templates (kept at origin as geometry sources) or stray helpers
 // (the "Plane" shadow catcher Android also hides). Everything else (a1..h8 tiles + frame) is shown.
 const HIDDEN_NODES = new Set(['king', 'queen', 'rook', 'bishop', 'knight', 'pawn', 'plane'])
@@ -253,7 +269,10 @@ window.chess3d = {
       // A re-init builds a fresh scene; drop pool slots pointing at the previous scene's nodes.
       piecePool.length = 0
       renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: false })
-      renderer.setPixelRatio(window.devicePixelRatio || 1)
+      // Part C: supersample the render buffer for crisper edges (the web regression was MSAA-only
+      // softness). The composer below renders into a HalfFloat MSAA target so AA stays sharp and
+      // bloom can work in HDR before the OutputPass tonemaps.
+      renderer.setPixelRatio(Math.min((window.devicePixelRatio || 1) * SS, SS_CAP))
       // Android (the visual reference) has NO cast shadows — it's lit purely by the papermill IBL,
       // whose radiance cube bakes in the sun's direction so the lighting already reads as sunlight
       // and stays fixed relative to the world as the camera orbits (as it would in nature). Adding
@@ -274,6 +293,26 @@ window.chess3d = {
       // Selection is shown by bouncing the picked piece (its y oscillates in setScene), not a disc.
 
       await loadGlb()
+      // Part C: build the post chain. RenderPass -> UnrealBloom (HDR) -> SMAA (edge AA) -> OutputPass
+      // (tonemap + sRGB). Wrapped so any addon/load failure falls back to the bare render loop below
+      // rather than a black canvas.
+      try {
+        const size = renderer.getDrawingBufferSize(new THREE.Vector2())
+        const rt = new THREE.WebGLRenderTarget(size.x, size.y, {
+          type: THREE.HalfFloatType, samples: 4, // MSAA-resolved HDR input = crisp silhouettes
+        })
+        composer = new EffectComposer(renderer, rt)
+        composer.addPass(new RenderPass(scene, camera))
+        bloomPass = new UnrealBloomPass(new THREE.Vector2(size.x, size.y), BLOOM_STRENGTH, BLOOM_RADIUS, BLOOM_THRESHOLD)
+        composer.addPass(bloomPass)
+        smaaPass = new SMAAPass(size.x, size.y)
+        composer.addPass(smaaPass)
+        composer.addPass(new OutputPass())
+        usePost = true
+      } catch (e) {
+        console.warn('[chess3d] EffectComposer init failed; falling back to bare render', e)
+        composer = null; bloomPass = null; smaaPass = null; usePost = false
+      }
       animate()
       return true
     } catch (e) {
@@ -337,12 +376,22 @@ window.chess3d = {
 
   resize(w, h) {
     if (!renderer) return
+    renderer.setPixelRatio(Math.min((window.devicePixelRatio || 1) * SS, SS_CAP))
     renderer.setSize(w, h, false)
     camera.aspect = w / h
     camera.updateProjectionMatrix()
+    // Part C: keep the composer + its passes in sync with the (supersampled) drawing buffer.
+    if (composer || bloomPass || smaaPass) {
+      const s = renderer.getDrawingBufferSize(new THREE.Vector2())
+      if (composer) composer.setSize(s.x, s.y)
+      if (bloomPass) bloomPass.setSize(s.x, s.y)
+      if (smaaPass) smaaPass.setSize(s.x, s.y)
+    }
   },
 
   dispose() {
+    if (composer) { composer.dispose(); composer = null }
+    bloomPass = null; smaaPass = null; usePost = false
     if (renderer) { renderer.dispose(); renderer = null }
     scene = null
     camera = null
@@ -408,7 +457,10 @@ async function loadGlb() {
 
 function animate() {
   requestAnimationFrame(animate)
-  if (renderer && scene && camera) renderer.render(scene, camera)
+  if (!renderer || !scene || !camera) return
+  // Part C: drive the post chain when the composer built; otherwise fall back to the bare render.
+  if (usePost && composer) composer.render()
+  else renderer.render(scene, camera)
 }
 
 """

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/ThreeJsChessRenderer.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/ThreeJsChessRenderer.kt
@@ -219,6 +219,15 @@ const SS_CAP = 2.5        // hard cap on the effective pixel ratio
 const BLOOM_STRENGTH = 0.7
 const BLOOM_RADIUS = 0.5
 const BLOOM_THRESHOLD = 0.6
+// De-band (mirrors the desktop Vulkan renderer): the glb whites/blacks albedo bakes high-contrast
+// horizontal wood grain and the shared metallicRoughness map's green channel is striped too, so on
+// the lathe-turned pieces both wrap into hard rings. We soften the albedo grain toward the per-
+// material mean wood colour and flatten roughness to a constant (even sheen, not glossy/matte bands).
+// Means measured from the glb albedos (sRGB).
+const WHITE_MEAN = [0.427, 0.361, 0.263]
+const BLACK_MEAN = [0.176, 0.114, 0.075]
+const GRAIN_STRENGTH = 0.5   // 1 = full grain; 0 = flat colour. 0.5 keeps subtle character.
+const PIECE_ROUGHNESS = 0.4  // constant roughness for pieces (replaces the striped roughnessMap)
 let composer, bloomPass, smaaPass   // alongside `renderer, scene, camera`
 let usePost = false                 // set true once the composer builds; falls back to bare render
 // Glb node names that are piece templates (kept at origin as geometry sources) or stray helpers
@@ -401,6 +410,37 @@ window.chess3d = {
   },
 }
 
+// De-band a shared piece material in place (see WHITE_MEAN/BLACK_MEAN comment). Flattens the striped
+// roughness/metalness maps to constants, and injects a tiny shader patch that pulls the sampled
+// albedo toward the per-material mean wood colour so the baked grain reads as subtle texture, not
+// hard rings — the three.js analogue of the desktop renderer's grainStrength/roughnessOverride.
+function debandPieceMaterial(mat, meanSrgb) {
+  if (!mat) return
+  // Flatten roughness: the glb metallicRoughness map's green channel is striped. Drop the map and
+  // use a constant; also drop the metalness map (wood is dielectric) so it can't add banding.
+  mat.roughnessMap = null
+  mat.roughness = PIECE_ROUGHNESS
+  mat.metalnessMap = null
+  mat.metalness = 0.0
+  // Soften the striped albedo grain toward the linearised mean. The map is sampled into linear space
+  // (three colour management), so `diffuseColor.rgb` after <map_fragment> is linear — mix toward the
+  // linearised mean there. GRAIN_STRENGTH == 1 would be a no-op.
+  const meanLin = new THREE.Vector3(
+    Math.pow(meanSrgb[0], 2.2), Math.pow(meanSrgb[1], 2.2), Math.pow(meanSrgb[2], 2.2),
+  )
+  mat.onBeforeCompile = (shader) => {
+    shader.uniforms.uGrainMean = { value: meanLin }
+    shader.uniforms.uGrainStrength = { value: GRAIN_STRENGTH }
+    shader.fragmentShader =
+      'uniform vec3 uGrainMean;\nuniform float uGrainStrength;\n' +
+      shader.fragmentShader.replace(
+        '#include <map_fragment>',
+        '#include <map_fragment>\n  diffuseColor.rgb = mix(uGrainMean, diffuseColor.rgb, uGrainStrength);',
+      )
+  }
+  mat.needsUpdate = true
+}
+
 async function loadGlb() {
   const loader = new GLTFLoader()
   const paths = ['./chess.glb', 'chess.glb', '/app/src/commonMain/composeResources/files/models/chess.glb']
@@ -418,6 +458,8 @@ async function loadGlb() {
   const materials = await gltf.parser.getDependencies('material')
   whiteMat = materials.find(m => m.name === 'white') || materials[0] || null
   blackMat = materials.find(m => m.name === 'black') || whiteMat
+  debandPieceMaterial(whiteMat, WHITE_MEAN)
+  debandPieceMaterial(blackMat, BLACK_MEAN)
 
   // Stash the six piece template meshes by kind (they sit at the glb origin).
   gltf.scene.traverse(o => {

--- a/docs/plans/3d-parity-desktop-bloom-web-aa.md
+++ b/docs/plans/3d-parity-desktop-bloom-web-aa.md
@@ -1,0 +1,580 @@
+# 3D Parity Pass 2 — Desktop materials/lighting/bloom + Web/iOS AA/bloom
+
+> **Status: PLAN ONLY — not implemented.** Implementation-ready spec for an autonomous coding agent
+> (Z.AI). Repo: `compose-multiplatform-chess`. All paths relative to repo root. Work on a branch off
+> `3d-animation-driver-web-parity` (suggested: `3d-parity-desktop-bloom-web-aa`).
+
+> [!CAUTION]
+> This plan deliberately edits the **frozen 3D platform actuals** (`VulkanChessRenderer`,
+> `chess3d-renderer.js`) that `CLAUDE.md` marks DO-NOT-TOUCH. That carve-out is authorized **for this
+> task only**. Do **not** unify rendering paths, port one backend onto another, or change Android
+> (`AndroidSceneViewChessRenderer`) — Android is the golden reference and stays as-is. Do not touch the
+> wgpu4k migration track. Do not change any `commonMain` public API or the
+> `Chess3DBoardRenderer`/`Board3DScene`/`Board3DSurface` contract.
+
+---
+
+## 0. Goal (what "done" looks like)
+
+Close two visual-parity gaps vs the Android Filament reference (the golden), per eyeballed review:
+
+- **Desktop (Vulkan)** — bigger gap, in **materials + lighting**: pieces are matte (weak specular/
+  gloss → wood-grain banding dominates, no polished "wet" look); lighting/post is flat, cool, neutral
+  with **no bloom** (loses Android's atmospheric depth); AO/contact shadows weak (pieces feel floaty);
+  board reflections muted. **AA is already good (8× MSAA + SSAA) — do not change AA on desktop.**
+- **Web + iOS (three.js, one shared renderer)** — materials are close, but the whole frame is **soft**
+  (MSAA-only AA, no supersample/post-AA — the main regression), and bloom/specular punch is slightly
+  subdued. Gloss/reflections are already close — preserve them.
+
+Scope decision (already made): **Desktop = shader tuning (Part A) + a real HDR bloom post pipeline
+(Part B). Web/iOS = AA + bloom via EffectComposer (Part C).**
+
+---
+
+## 1. How to work (execution rules for the agent)
+
+1. **Edit only the source-of-truth files. Never hand-edit generated copies.**
+   - Web/iOS renderer: edit `tools/chess3d-renderer/chess3d-renderer.js`, then run
+     `node tools/chess3d-renderer/build.mjs` to regenerate **both** copies (the iOS bundle and the
+     `CHESS3D_RENDERER_JS` Kotlin string). Hand-editing `iosApp/iosApp/Resources/chess3d-bundle.js` or
+     the string in `ThreeJsChessRenderer.kt` is forbidden.
+   - Desktop renderer: all shaders + pipeline code live in
+     `app/src/desktopMain/kotlin/com/example/myapplication/board3d/VulkanChessRenderer.kt`.
+2. **Land in the commit order at the bottom (Part A, then B, then C). Each part builds + eyeballs
+   green before the next.** Bloom (B) is the highest-risk change — do not start it until A is verified.
+3. **Eyeball loops (this is how you verify rendering — there is no pixel-diff CI):**
+   - Desktop: `./gradlew :app:desktopTest --tests "*DesktopRendererSmokeTest*" -Dchess3d.smoke=true`
+     renders start / selected / after-e4 and writes `app/build/chess3d-*.png` (downscaled = what the
+     user sees) + `app/build/raw-chess3d-*.png` (full supersampled). Needs MoltenVK (present on macOS).
+     **Capture a baseline before Part A** (`cp app/build/chess3d-start.png app/build/baseline-start.png`)
+     and visually compare after each step.
+   - Web: `./gradlew :app:wasmJsBrowserDevelopmentRun`, inspect in a real browser.
+   - iOS (verifies the *same* shared JS): `tools/ios_3d_screenshot.sh` → `build/ios-3d-screenshot.png`.
+4. **Full-build gate (a change is not done until all targets build):**
+   ```bash
+   ./gradlew :androidApp:assembleDebug :app:assembleAndroidDeviceTest :app:check \
+     :app:desktopJar :app:packageDistributionForCurrentOS :app:wasmJsBrowserDistribution
+   ```
+   Do not regress existing 3D tests: `./gradlew :app:desktopTest --tests "*board3d*"`.
+5. **Expose every magic number as a named constant/tunable next to the existing look knobs**
+   (`VulkanChessRenderer.kt:73`–`76`; module consts near `PIECE_SCALE` in the JS), with a one-line
+   comment, so they can be tuned without spelunking.
+
+---
+
+## 2. Current architecture (verified facts the plan relies on)
+
+### 2.1 Desktop Vulkan (`VulkanChessRenderer.kt`)
+- **Headless, single render thread** (`renderDispatcher`), one reusable primary command buffer
+  (`commandBuffer`), one `fence`. Per frame: `renderFrame()` (`:215`) → `recordCommandBuffer()`
+  (`:230`) → submit + wait → `readbackToImageBitmap()` (`:349`) → `surf.onFrame(...)`.
+- **All shaders are GLSL string consts compiled at runtime via shaderc** (`createShaderModule()`
+  `:1040`). A fullscreen-triangle vertex shader already exists: `FSQ_VERT` (`:1857`, emits UV via
+  `gl_VertexIndex`, used by `BRDF_LUT_FRAG`). **Reuse `FSQ_VERT` for all new post passes.**
+- **Frame record order** (`recordCommandBuffer` `:230`): (1) shadow depth pass into `shadowFramebuffer`
+  (`:238`), (2) main pass into `framebuffer` (`:263`): bind `skyPipeline`, draw fullscreen sky tri
+  (`:282`), then bind `pipeline` and draw each `ChessTexture` group (`:284`–`309`), (3)
+  `vkCmdCopyImageToBuffer(resolveImage → readbackBuffer)` (`:317`).
+- **Main render pass** `createRenderPass()` (`:884`): 3 attachments — [0] MSAA color (`colorImage`,
+  `samples`, format `colorFormat`=`VK_FORMAT_R8G8B8A8_UNORM`, finalLayout COLOR_ATTACHMENT_OPTIMAL,
+  storeOp DONT_CARE), [1] MSAA depth, [2] **single-sample resolve** (`resolveImage`, `colorFormat`,
+  storeOp STORE, **finalLayout `VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL`**). Subpass resolves [0]→[2].
+  **No explicit `VkSubpassDependency` today.** The copy reads `resolveImage` as TRANSFER_SRC.
+- **Targets are (re)allocated in `ensureTargets(w,h)` (`:1247`)** and freed in `destroyTargets()`
+  (`:1396`). `width/height` store the **SSAA-scaled** dims (`ssaaScale` `:1243`, default 2, env
+  `CHESS_DESKTOP_SSAA`). Framebuffer attaches `colorView, depthView, resolveView` (`:1263`).
+  `readbackBuffer` sized `width*height*4`.
+- **Scene fragment shader `FRAG_GLSL` (`:1518`)** outputs tonemapped LDR. Key lines:
+  - sun color `vec3(3.8,3.4,2.8)` (`:1608`).
+  - IBL diffuse: `irradiance *= vec3(1.25,1.08,0.85)` (`:1659`); `diffuse = irradiance*albedo*0.6` (`:1660`).
+  - **IBL specular: `vec3 specular = reflection*(F*brdf.x+brdf.y)*0.5;` (`:1667`) ← deliberately
+    halved; main cause of matte pieces + muted reflections.**
+  - `metallic = mat.metallicFactor*mr.b` (`:1637`); `roughness = clamp(mat.roughnessFactor*mr.g, 0.05, 1.0)` (`:1638`).
+  - `ambient = kD*diffuse + specular` (`:1671`); `color = ambient + Lo` (`:1673`).
+  - Uncharted2 tonemap + gamma at `:1680`–`1682`. `SKY_FRAG` tonemaps identically (`:1726`–`1730`).
+  - **No AO is sampled today.** `mrTex` is bound at binding 8; per glTF, its **R channel = occlusion**.
+- **Per-draw push constants** (`MaterialParams`, 32 bytes, `:1535` / written `:292`–`300`):
+  `vec4 baseColorFactor; float metallicFactor; float roughnessFactor; vec2 pad;` — **the `pad` at
+  byte offset 24 is free real estate** for a per-material roughness scale (Part A.2).
+- **Material groups**: `ChessTexture.entries` (board/marble, WHITE wood, BLACK wood). The loop at
+  `:285` knows `tex`, so per-group constants (e.g. piece-only roughness scale) are trivial to push.
+  `GltfChessTextures.kt:87` notes piece MR has **B pinned to 255** (so metallic is forced 0 for
+  pieces) — meaning for pieces only `mr.g` (roughness) and `mr.r` (AO) are meaningful from that tex.
+- **Helpers you will reuse verbatim** (do not reinvent): `createImage(w,h,format,usage,samples=1)`
+  (`:1301`), `createImageView(image,format,aspect,...)` (`:1314`), `createBuffer` (`:1378`),
+  `transition(cmd,stack,image,old,new,srcAccess,dstAccess,srcStage,dstStage)` (`:1214`),
+  `createShaderModule` (`:1040`), the descriptor-write pattern in `uploadTexture` (`:1062`).
+- **Format support**: `getMaxUsableSampleCount()` (`:874`) picks `samples` from
+  `framebufferColorSampleCounts & framebufferDepthSampleCounts` — format-agnostic. `envFormat =
+  VK_FORMAT_R16G16B16A16_SFLOAT` (`:80`) is already created+sampled as a cube, so RGBA16F sampling is
+  proven on the device; you additionally need it as a **COLOR_ATTACHMENT** (and MSAA) — see B.0 check.
+
+### 2.2 Web + iOS three.js (`tools/chess3d-renderer/chess3d-renderer.js`, 231 lines)
+- `WebGLRenderer({antialias:true, alpha:false})`, `setPixelRatio(devicePixelRatio||1)` (`:75`),
+  `ACESFilmicToneMapping`, exposure 1.0, `outputColorSpace=SRGBColorSpace`, `shadowMap.enabled=false`.
+- Lighting = papermill HDR skybox + PMREM IBL (`loadEnvironment` `:47`); pieces use the glb's own
+  `white`/`black` materials; whole glb shown at scale 0.5.
+- **Render loop is a bare `renderer.render(scene,camera)`** in `animate()` (`:228`). Resize =
+  `renderer.setSize(w,h,false)` (`:157`). MSAA-only AA = the softness.
+- Web resolves `three` + `three/addons/` via the **static import map** in
+  `app/src/wasmJsMain/resources/index.html:11`, pinned to **`three@0.169.0`** (jsDelivr). iOS bundles
+  via esbuild (`bundle:true`, `format:'iife'`) from `tools/chess3d-renderer/node_modules` — so any new
+  addon import is bundled offline automatically. **Pin all new imports to the same `three@0.169.0`.**
+
+---
+
+## Part A — Desktop Vulkan: material/lighting shader tuning (low risk)
+
+Land these **first**, one at a time, re-running the smoke test after each. They are confined to
+`FRAG_GLSL`, three new tunables, and one extra push-constant byte slot — **no render-pass/pipeline/
+attachment changes**, so each is independently revertible.
+
+### A.1 New tunables
+Add next to `exposure`/`gamma` (`VulkanChessRenderer.kt:75`):
+```kotlin
+// Part A look tunables (Pass-2 parity). Eyeball via DesktopRendererSmokeTest.
+private val iblSpecularScale = 0.85f   // was hard-coded 0.5 in FRAG_GLSL; restores gloss + board reflections
+private val aoStrength = 1.0f          // how strongly mrTex.r (glTF occlusion) darkens the IBL ambient term
+private val contactStrength = 0.35f    // how much the shadow factor deepens ambient at piece/board contact
+```
+Raise `exposure` `4.0f → 4.3f` (warmer, less flat). These four floats feed the shader via a small
+UBOParams extension **or** simpler: bake `iblSpecularScale`/`aoStrength`/`contactStrength` directly as
+GLSL literals (they are constants, not animated). Prefer literals to avoid touching the 32-byte
+UBOParams layout; keep the Kotlin vals as the documented source of the chosen numbers.
+
+### A.2 Per-material roughness scale (pieces glossier, board unchanged)
+- In `recordCommandBuffer` material loop (`:292`), set the free pad slot to a per-group roughness
+  scale:
+  ```kotlin
+  val roughScale = if (tex == ChessTexture.WHITE || tex == ChessTexture.BLACK) 0.8f else 1.0f
+  matPush.putFloat(24, roughScale)   // was pad; offset 24
+  matPush.putFloat(28, 0f)
+  ```
+- In `FRAG_GLSL` rename the push-constant tail and use it:
+  ```glsl
+  layout(push_constant) uniform MaterialParams {
+      vec4 baseColorFactor;
+      float metallicFactor;
+      float roughnessFactor;
+      float roughnessScale;   // offset 24 (was pad.x)
+      float pad;
+  } mat;
+  ...
+  float roughness = clamp(mat.roughnessFactor * mr.g * mat.roughnessScale, 0.04, 1.0); // was floor 0.05
+  ```
+
+### A.3 IBL specular + AO + contact grounding in `FRAG_GLSL`
+Replace the IBL/ambient block (`:1658`–`1673`) with (note the three new factors and the AO sample):
+```glsl
+    vec3 irradiance = texture(irradiance, N).rgb;
+    irradiance *= vec3(1.25, 1.08, 0.85);                 // existing warm tint
+    vec3 diffuse = irradiance * albedo * 0.6;
+
+    vec3 reflection = prefilteredReflection(R, roughness);
+    vec2 brdf = texture(brdfLUT, vec2(max(dot(N, V), 0.0), roughness)).rg;
+    vec3 F = F_SchlickR(max(dot(N, V), 0.0), F0, roughness);
+    vec3 specular = reflection * (F * brdf.x + brdf.y) * 0.85;   // A.1: was 0.5 -> gloss + reflections
+
+    vec3 kD = 1.0 - F;
+    kD *= 1.0 - metallic;
+    vec3 ambient = kD * diffuse + specular;
+
+    // A.3: glTF occlusion (mrTex.r) darkens only the indirect/ambient term. Piece MR.r is ~flat so
+    // this mostly grounds the marble board/frame; it is a no-op where R==1, so it is safe globally.
+    float ao = mr.r;
+    ambient *= mix(1.0, ao, 1.0);                          // aoStrength = 1.0
+    // A.3: deepen contact shadow on the ambient fill so pieces sit on the board instead of floating.
+    ambient *= mix(1.0 - 0.35, 1.0, sh);                  // contactStrength = 0.35
+
+    vec3 color = ambient + Lo;
+```
+(`mr` is already fetched at `:1636`; `sh` at `:1647`. No new bindings.)
+
+### A.4 Tone
+Keep `gamma=2.2`. With `exposure=4.3` and the gloss/AO above, re-check the smoke PNGs; if whites clip,
+trim `exposure` toward `4.1`. Do **not** change the tonemap operator here — bloom (Part B) supplies
+the remaining "atmosphere".
+
+**Part A acceptance:** `chess3d-start.png` vs `baseline-start.png` shows glossier pieces, visible dark-
+square board reflections, grounded contact, slightly warmer frame; no blown highlights, board not
+mirror-slick. The smoke test still passes its "many colours / board fills frame" asserts. **Commit A.**
+
+### A.5 De-band the piece materials (VERIFIED — added after Part A made it worse)
+
+**Root cause (confirmed by extracting the glb textures, `app/build/glb-tex/`):** the chess set's
+`whites`/`blacks` **albedo** maps bake very high-contrast horizontal **wood-grain banding**, and the
+shared `metallicRoughness` map's **green (roughness) channel is also striped** (blue/metallic pinned
+at 255). On the lathe-turned geometry both wrap into hard concentric rings. Part A's specular boost
+(0.5→0.85) *amplified* the striped-roughness rings (alternating glossy/matte bands, blue sky-reflection
+catching the glossy ones) — so the pieces looked **more** unnatural, not less. This is an **asset
+problem**; no lighting/bloom tuning fixes it. The renderer must actively tame the grain.
+
+**Fix (per-material, pieces only; board untouched):**
+- **Soften albedo grain:** pull albedo toward the per-material mean wood colour —
+  `albedoLin = mix(grainMeanLin, albedoLin, grainStrength)`. Means measured from the glb albedos:
+  white `(0.427,0.361,0.263)` sRGB, black `(0.176,0.114,0.075)` sRGB. `grainStrength = 0.5` for
+  pieces keeps half the grain (subtle character); `1.0` for the board (no-op).
+- **Flatten roughness:** ignore the striped `mr.g` for pieces — `roughnessOverride = 0.4` gives an even
+  polished sheen; `0` (sentinel) for the board keeps its textured roughness.
+- Pushed via three new `MaterialParams` fields (`grainStrength`, `grainMean*`, `roughnessOverride`),
+  bumping the fragment push-constant range 32→48 bytes. Implemented in `FRAG_GLSL` (`main`) +
+  `recordCommandBuffer` material loop + `createPipeline` push range.
+
+**Verified:** rebuilt + ran `DesktopRendererSmokeTest -Dchess3d.smoke=true` on this branch — the rings
+are gone; pieces read as smooth ivory/ebony with subtle grain. `grainStrength`/`roughnessOverride` are
+the tuning knobs (lower grainStrength → cleaner; raise → more wood character).
+
+---
+
+## Part B — Desktop Vulkan: HDR bloom post pipeline (higher risk, staged)
+
+Bloom must extract bright regions **in HDR, before tonemapping**. Today the scene fragment tonemaps
+to LDR and resolves straight to `resolveImage`. The change: **resolve the scene to an HDR texture,
+run a fullscreen post chain (bright → blur → composite), and tonemap in the final composite pass that
+writes the existing LDR `resolveImage`** (so `vkCmdCopyImageToBuffer` is untouched). Architecture
+mirrors the existing offscreen passes (BRDF LUT / irradiance) and reuses `FSQ_VERT`.
+
+```
+shadow → SCENE(MSAA, linear HDR) --resolve--> sceneHdr(R16F)
+                                                  │ sample
+                                bright(½ R16F) ◄──┘  (threshold + soft knee)
+                                   │ sample
+          blurH→A(½)  blurV→B(½)  blurH→A(½)  blurV→B(½)   (separable, 2 iters)
+                                                  │ bloom=B
+   composite: sceneHdr + bloom*intensity → Uncharted2 tonemap+gamma → resolveImage(LDR R8) → copy
+```
+
+### B.0 Pre-flight (must do first)
+- Add `private val hdrFormat = VK_FORMAT_R16G16B16A16_SFLOAT`.
+- **Verify the device supports `hdrFormat` as a multisampled color attachment.** In `initVulkan`
+  after `samples` is chosen, query `vkGetPhysicalDeviceImageFormatProperties(hdrFormat, OPTIMAL,
+  COLOR_ATTACHMENT|SAMPLED|TRANSFER_SRC)` and clamp `samples` to its `sampleCounts` (MoltenVK
+  supports 4×/8× RGBA16F; this guards weird drivers). Also gate the whole bloom path behind
+  `CHESS_DESKTOP_BLOOM` (env, default on; `0` = keep the current LDR single-pass path) so it is a
+  one-line kill switch and the smoke test stays bisectable.
+- Add an env tunable block by the others:
+  ```kotlin
+  private val bloomEnabled = System.getenv("CHESS_DESKTOP_BLOOM")?.trim() != "0"
+  private val bloomThreshold = 1.1f   // HDR luma above which pixels bloom
+  private val bloomKnee = 0.5f        // soft-knee width below threshold
+  private val bloomIntensity = 0.5f   // additive bloom strength in composite
+  private val bloomIterations = 2     // H+V blur passes
+  ```
+
+### B.1 Fields (add near `colorImage`/`resolveImage`, `:86`–`88`)
+```kotlin
+// HDR scene resolve target (sampled by the bloom chain).
+private var sceneHdrImage = VK_NULL_HANDLE; private var sceneHdrMem = VK_NULL_HANDLE; private var sceneHdrView = VK_NULL_HANDLE
+// Half-res ping-pong bloom targets (all hdrFormat, SAMPLED|COLOR_ATTACHMENT).
+private var bloomW = 0; private var bloomH = 0
+private var bloomBright = VK_NULL_HANDLE; private var bloomBrightMem = VK_NULL_HANDLE; private var bloomBrightView = VK_NULL_HANDLE
+private var bloomA = VK_NULL_HANDLE; private var bloomAMem = VK_NULL_HANDLE; private var bloomAView = VK_NULL_HANDLE
+private var bloomB = VK_NULL_HANDLE; private var bloomBMem = VK_NULL_HANDLE; private var bloomBView = VK_NULL_HANDLE
+// Post render passes + pipelines (created once; format-fixed).
+private var postRenderPass = VK_NULL_HANDLE      // single hdr color attachment, finalLayout SHADER_READ_ONLY
+private var compositeRenderPass = VK_NULL_HANDLE // single ldr color attachment, finalLayout TRANSFER_SRC
+private var postSetLayout = VK_NULL_HANDLE; private var postPool = VK_NULL_HANDLE
+private var brightPipelineLayout = VK_NULL_HANDLE; private var brightPipeline = VK_NULL_HANDLE
+private var blurPipelineLayout = VK_NULL_HANDLE; private var blurPipeline = VK_NULL_HANDLE
+private var compositePipelineLayout = VK_NULL_HANDLE; private var compositePipeline = VK_NULL_HANDLE
+// Framebuffers + per-input descriptor sets (resize-dependent; rebuilt in ensureTargets).
+private var sceneFramebuffer = VK_NULL_HANDLE     // color(MSAA hdr) + depth + sceneHdr(resolve)
+private var brightFb = VK_NULL_HANDLE; private var aFb = VK_NULL_HANDLE; private var bFb = VK_NULL_HANDLE
+private var compositeFb = VK_NULL_HANDLE
+private var dsSceneHdr = VK_NULL_HANDLE; private var dsBright = VK_NULL_HANDLE
+private var dsA = VK_NULL_HANDLE; private var dsB = VK_NULL_HANDLE; private var dsComposite = VK_NULL_HANDLE
+```
+> Rename the existing `framebuffer` usage in the scene pass to `sceneFramebuffer` (the scene pass now
+> resolves into `sceneHdr`, not the LDR target). `resolveImage`/`resolveMem`/`resolveView` are
+> **repurposed** as the composite (LDR) output — keep the names to minimize churn.
+
+### B.2 Render passes
+- **Scene pass** (`createRenderPass`, `:884`): change attachment[0] (MSAA color) and attachment[2]
+  (resolve) `format(colorFormat)` → `format(hdrFormat)`; change attachment[2] `finalLayout`
+  `TRANSFER_SRC_OPTIMAL` → `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`. Add **one** subpass dependency
+  `srcSubpass=0, dst=EXTERNAL; srcStage=COLOR_ATTACHMENT_OUTPUT, dstStage=FRAGMENT_SHADER;
+  srcAccess=COLOR_ATTACHMENT_WRITE, dstAccess=SHADER_READ; flags=BY_REGION` so the bright pass can
+  sample `sceneHdr`.
+- **`postRenderPass`** (new): 1 color attachment, `hdrFormat`, `VK_SAMPLE_COUNT_1_BIT`, loadOp
+  DONT_CARE, storeOp STORE, initialLayout UNDEFINED, finalLayout SHADER_READ_ONLY_OPTIMAL. Add **two**
+  external dependencies (in: `EXTERNAL→0`, FRAGMENT_SHADER/SHADER_READ → COLOR_ATTACHMENT_OUTPUT/
+  COLOR_ATTACHMENT_WRITE; out: `0→EXTERNAL`, COLOR_ATTACHMENT_OUTPUT/WRITE → FRAGMENT_SHADER/READ,
+  BY_REGION) so consecutive bright/blur passes serialize correctly. One render pass object is shared
+  by bright + all blur passes (same format), with different framebuffers.
+- **`compositeRenderPass`** (new): 1 color attachment, `colorFormat` (LDR), 1 sample, loadOp
+  DONT_CARE, storeOp STORE, finalLayout `TRANSFER_SRC_OPTIMAL`. Dependencies: in `EXTERNAL→0`
+  (FRAGMENT_SHADER/SHADER_READ → COLOR_ATTACHMENT_OUTPUT/WRITE); out `0→EXTERNAL`
+  (COLOR_ATTACHMENT_OUTPUT/WRITE → **TRANSFER**/TRANSFER_READ) so the trailing
+  `vkCmdCopyImageToBuffer` is correctly ordered.
+
+### B.3 Post descriptor layout + pool + pipelines (create once in `initVulkan`)
+- `postSetLayout`: 2 bindings, both `COMBINED_IMAGE_SAMPLER`, fragment stage (binding 0 = primary
+  input, binding 1 = second input for composite; bright/blur bind the same view to both — harmless).
+- `postPool`: `maxSets=5`, `COMBINED_IMAGE_SAMPLER` count `= 5*2`.
+- Three pipelines, all using `FSQ_VERT` (no vertex buffers, `vkCmdDraw(cmd,3,1,0,0)`), no depth, no
+  blend, `rasterizationSamples(VK_SAMPLE_COUNT_1_BIT)`, dynamic viewport+scissor (mirror
+  `buildBrdfLut`'s pipeline setup at `:543`–`:566`):
+  - `brightPipeline` (`postRenderPass`, `BRIGHT_FRAG`, push: `vec4{threshold,knee,_,_}`).
+  - `blurPipeline` (`postRenderPass`, `BLUR_FRAG`, push: `vec4{texelX,texelY,dirX,dirY}`).
+  - `compositePipeline` (`compositeRenderPass`, `COMPOSITE_FRAG`, push:
+    `vec4{bloomIntensity,exposure,gamma,_}`).
+  - Each push-constant range is `VK_SHADER_STAGE_FRAGMENT_BIT`, size 16, offset 0. Each pipeline layout
+    uses `postSetLayout`.
+
+### B.4 Target creation in `ensureTargets` (`:1247`) and teardown in `destroyTargets` (`:1396`)
+After computing `rw,rh` and before building the framebuffer:
+- `colorImage` MSAA: change its `createImage(... colorFormat ...)` (`:1256`) to `hdrFormat`.
+- Create `sceneHdrImage` (1 sample, `hdrFormat`, `COLOR_ATTACHMENT|SAMPLED`) + view.
+- Keep `resolveImage` but recreate it as `colorFormat` (LDR), usage `COLOR_ATTACHMENT|TRANSFER_SRC`
+  (it is now the composite output, no longer an MSAA resolve target).
+- `bloomW=max(1,rw/2); bloomH=max(1,rh/2)`. Create `bloomBright/bloomA/bloomB` (1 sample, `hdrFormat`,
+  `COLOR_ATTACHMENT|SAMPLED`) + views.
+- Framebuffers: `sceneFramebuffer`(colorView, depthView, **sceneHdrView**) over `renderPass`;
+  `brightFb`(bloomBrightView)/`aFb`(bloomAView)/`bFb`(bloomBView) over `postRenderPass` at bloom size;
+  `compositeFb`(resolveView) over `compositeRenderPass` at full size.
+- (Re)allocate the 5 descriptor sets from `postPool` (free/reset on resize) and write them with the
+  `brdfLutSampler` (linear, clamp-to-edge, no mip — perfect for these 1-mip targets):
+  - `dsSceneHdr` → binding0,1 = `sceneHdrView`
+  - `dsBright` → `bloomBrightView`; `dsA` → `bloomAView`; `dsB` → `bloomBView`
+  - `dsComposite` → binding0 = `sceneHdrView`, binding1 = `bloomBView`
+- `destroyTargets`: destroy all the new images/views/mem + the 5 framebuffers; free the post DSs
+  (or `vkResetDescriptorPool(postPool)`). Mirror the existing destroy ordering.
+
+### B.5 Record order in `recordCommandBuffer` (replace the main pass + copy, `:263`–`317`)
+Keep the shadow pass unchanged. Then:
+1. Scene pass into `sceneFramebuffer` (everything currently at `:263`–`311`, unchanged draws). The
+   scene shaders now output **linear HDR** (see B.6).
+2. If `bloomEnabled`:
+   - **bright**: begin `postRenderPass`/`brightFb` at (bloomW,bloomH); bind `brightPipeline` + `dsSceneHdr`;
+     push `{bloomThreshold,bloomKnee,0,0}`; `vkCmdDraw(3,1,0,0)`; end.
+   - **blur loop** (`bloomIterations` × H then V), texel = `(1f/bloomW, 1f/bloomH)`:
+     - H: `postRenderPass`/`aFb`, `blurPipeline` + (iter 0 ? `dsBright` : `dsB`), push `{texelX,texelY,1,0}`.
+     - V: `postRenderPass`/`bFb`, `blurPipeline` + `dsA`, push `{texelX,texelY,0,1}`.
+   - **composite**: `compositeRenderPass`/`compositeFb` at (width,height); `compositePipeline` +
+     `dsComposite`; push `{bloomIntensity,exposure,gamma,0}`; draw.
+   - Else (bloom off): a trivial composite that samples only `sceneHdr` and tonemaps (so the LDR path
+     still works) — or keep the old single-pass path behind the `bloomEnabled` branch.
+3. `vkCmdCopyImageToBuffer(resolveImage, TRANSFER_SRC_OPTIMAL, readbackBuffer, region)` — **unchanged**
+   (`resolveImage` is now the composite output). The render-pass out-dependency (B.2) orders it.
+
+> Render-pass `finalLayout`s do the image transitions; the subpass dependencies (B.2) do the execution/
+> memory ordering. **Do not add manual `vkCmdPipelineBarrier`s between passes** unless validation
+> complains — if it does, add a barrier matching the dependency you missed.
+
+### B.6 Move tonemapping out of the scene shaders into composite
+- In `FRAG_GLSL` (`:1680`–`1682`) and `SKY_FRAG` (`:1726`–`1730`), **delete** the
+  `Uncharted2Tonemap(...) * (1/Uncharted2Tonemap(11.2))` and `pow(color, 1/gamma)` lines so both
+  output **linear HDR radiance**. Keep `clamp(color*exposure, 0, 256)`? No — move the `* exposure`
+  into composite too; scene/sky now write raw linear radiance. The selection glow (`:1676`) stays
+  additive in HDR (it will bloom — desirable).
+
+### B.7 New shaders (append by the other GLSL consts, ~`:1855`)
+```glsl
+// BRIGHT_FRAG — threshold with soft knee (Karis/UE style).
+#version 450
+layout(location = 0) in vec2 inUV;
+layout(set = 0, binding = 0) uniform sampler2D src;
+layout(push_constant) uniform PC { vec4 p; } pc; // p.x=threshold, p.y=knee
+layout(location = 0) out vec4 outColor;
+void main() {
+    vec3 c = texture(src, inUV).rgb;
+    float br = max(c.r, max(c.g, c.b));
+    float knee = max(pc.p.y, 1e-4);
+    float soft = clamp((br - pc.p.x + knee) / (2.0 * knee), 0.0, 1.0);
+    float w = max(soft * soft, step(pc.p.x, br)); // soft knee below, hard above
+    outColor = vec4(c * w, 1.0);
+}
+```
+```glsl
+// BLUR_FRAG — separable 9-tap Gaussian; direction in push constant.
+#version 450
+layout(location = 0) in vec2 inUV;
+layout(set = 0, binding = 0) uniform sampler2D src;
+layout(push_constant) uniform PC { vec4 p; } pc; // p.xy=texel, p.zw=dir (1,0) or (0,1)
+layout(location = 0) out vec4 outColor;
+const float W[5] = float[](0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
+void main() {
+    vec2 step = pc.p.xy * pc.p.zw;
+    vec3 c = texture(src, inUV).rgb * W[0];
+    for (int i = 1; i < 5; i++) {
+        c += texture(src, inUV + step * float(i)).rgb * W[i];
+        c += texture(src, inUV - step * float(i)).rgb * W[i];
+    }
+    outColor = vec4(c, 1.0);
+}
+```
+```glsl
+// COMPOSITE_FRAG — scene + bloom, then Uncharted2 tonemap + gamma (the only tonemap now).
+#version 450
+layout(location = 0) in vec2 inUV;
+layout(set = 0, binding = 0) uniform sampler2D sceneHdr;
+layout(set = 0, binding = 1) uniform sampler2D bloomTex;
+layout(push_constant) uniform PC { vec4 p; } pc; // p.x=intensity, p.y=exposure, p.z=gamma
+layout(location = 0) out vec4 outColor;
+vec3 Uncharted2Tonemap(vec3 x) {
+    float A=0.15,B=0.50,C=0.10,D=0.20,E=0.02,F=0.30;
+    return ((x*(A*x+C*B)+D*E)/(x*(A*x+B)+D*F))-E/F;
+}
+void main() {
+    vec3 hdr = texture(sceneHdr, inUV).rgb + texture(bloomTex, inUV).rgb * pc.p.x;
+    vec3 col = Uncharted2Tonemap(clamp(hdr * pc.p.y, 0.0, 256.0));
+    col *= 1.0 / Uncharted2Tonemap(vec3(11.2));
+    col = pow(col, vec3(1.0 / pc.p.z));
+    outColor = vec4(col, 1.0);
+}
+```
+
+### B.8 Staged rollout (do NOT write it all at once)
+1. **B-step 1 (HDR round-trip, no bloom):** B.0/B.1/B.2 scene-pass format change + a *composite-only*
+   pass (`dsComposite` binding1 also = sceneHdr, intensity 0) + B.6 tonemap move. Skip bright/blur.
+   Run smoke test — image must look ~identical to end-of-Part-A. This isolates "did HDR resolve +
+   composite break the picture" from blur bugs.
+2. **B-step 2 (bloom on):** add bright + blur passes and point composite binding1 at `bloomBView`.
+   Tune `bloomThreshold`/`bloomIntensity` against Android (subtle halo on bright highlights, no
+   ringing/banding).
+3. Run `VulkanFpsBenchmark` (`-Dchess3d.bench`); half-res bloom should be cheap even at SSAA×2. If
+   slow, drop bloom to quarter-res (`/4`) or reduce `bloomIterations`.
+
+### B.9 Risks / rollback
+- Highest-risk part: subpass dependencies + descriptor-set rewrite-on-resize. Enable Vulkan
+  validation layers while developing if available; the layout/ordering mistakes surface there.
+- `CHESS_DESKTOP_BLOOM=0` reverts to the LDR path at runtime; reverting the Part B commit reverts
+  entirely. Part A stands alone.
+
+**Part B acceptance:** bright pieces/highlights bleed a soft halo, scene gains Android-like
+atmospheric depth, no banding/ringing, FPS within budget, smoke-test asserts still pass, and
+`CHESS_DESKTOP_BLOOM=0` reproduces the Part-A look.
+
+---
+
+## Part C — Web + iOS three.js: AA + bloom (EffectComposer)
+
+All edits in `tools/chess3d-renderer/chess3d-renderer.js`; then `node tools/chess3d-renderer/build.mjs`.
+Replace the bare `renderer.render()` with an `EffectComposer` chain that supplies **both** crisper AA
+(MSAA HDR target + supersample + SMAA) and bloom.
+
+### C.1 Imports (top of file, pinned to three@0.169.0 via the import map / esbuild)
+```js
+import { EffectComposer }  from 'three/addons/postprocessing/EffectComposer.js'
+import { RenderPass }      from 'three/addons/postprocessing/RenderPass.js'
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
+import { SMAAPass }        from 'three/addons/postprocessing/SMAAPass.js'
+import { OutputPass }      from 'three/addons/postprocessing/OutputPass.js'
+```
+
+### C.2 Tunables (module consts near `PIECE_SCALE`, `:23`)
+```js
+const SS = 1.5            // render-buffer supersample factor (sharpness); costs fill rate
+const SS_CAP = 2.5        // hard cap on effective pixel ratio
+const BLOOM_STRENGTH = 0.25
+const BLOOM_RADIUS = 0.4
+const BLOOM_THRESHOLD = 0.85
+let composer, bloomPass, smaaPass   // module-scope, alongside `renderer, scene, camera`
+```
+
+### C.3 Build the composer in `init` (after renderer/scene/camera, replacing nothing else)
+```js
+renderer.setPixelRatio(Math.min((window.devicePixelRatio || 1) * SS, SS_CAP))
+// Keep renderer.toneMapping = ACESFilmicToneMapping and outputColorSpace = SRGB as-is; OutputPass
+// applies them. RenderPass renders the scene LINEAR into a HalfFloat MSAA target (sharp AA), then
+// bloom works in HDR, SMAA cleans remaining edges, OutputPass tonemaps + converts to sRGB last.
+const size = renderer.getDrawingBufferSize(new THREE.Vector2())
+const rt = new THREE.WebGLRenderTarget(size.x, size.y, {
+  type: THREE.HalfFloatType, samples: 4,                 // MSAA-resolved input = crisp
+})
+composer = new EffectComposer(renderer, rt)
+composer.addPass(new RenderPass(scene, camera))
+bloomPass = new UnrealBloomPass(new THREE.Vector2(size.x, size.y), BLOOM_STRENGTH, BLOOM_RADIUS, BLOOM_THRESHOLD)
+composer.addPass(bloomPass)
+smaaPass = new SMAAPass(size.x, size.y)
+composer.addPass(smaaPass)
+composer.addPass(new OutputPass())
+```
+> Wrap composer construction in the existing `try/catch` of `init` (`:98`) so an addon/load failure
+> falls back to the bare `renderer.render` loop rather than a black canvas. Set a module flag
+> `usePost = !!composer` to branch in `animate`.
+
+### C.4 Render loop + resize + dispose
+- `animate()` (`:228`): `if (usePost && composer) composer.render(); else renderer.render(scene, camera)`.
+- `resize(w, h)` (`:157`): after `renderer.setSize(w,h,false)` and the camera update, add:
+  ```js
+  renderer.setPixelRatio(Math.min((window.devicePixelRatio || 1) * SS, SS_CAP))
+  const s = renderer.getDrawingBufferSize(new THREE.Vector2())
+  if (composer) composer.setSize(s.x, s.y)
+  if (bloomPass) bloomPass.setSize(s.x, s.y)
+  if (smaaPass) smaaPass.setSize(s.x, s.y)
+  ```
+- `dispose()` (`:164`): `if (composer) { composer.dispose(); composer = null }` before disposing the
+  renderer; null `bloomPass`/`smaaPass`.
+
+### C.5 Regenerate + verify
+```bash
+node tools/chess3d-renderer/build.mjs            # rewrites ios bundle + ThreeJsChessRenderer.kt string
+git diff --stat                                  # MUST show both generated copies changed
+tools/ios_3d_screenshot.sh                       # eyeball build/ios-3d-screenshot.png (shared renderer)
+./gradlew :app:wasmJsBrowserDevelopmentRun       # eyeball web in a real browser
+```
+- Confirm the **iOS bundle runs fully offline** — esbuild must have inlined EffectComposer + bloom +
+  SMAA (SMAA ships its search/area textures as embedded base64, so no runtime fetch). Bundle grows
+  ~80–120 KB; that is expected.
+- Web only: the new addon imports resolve through the existing `three/addons/` import-map entry
+  (`index.html:15`) — no `index.html` change needed, but verify no 404s in the browser console.
+
+**Part C acceptance:** web + iOS frame is crisp (sharp silhouettes/sculpt detail, no upscaled
+softness), bloom adds subtle Android-matching punch, gloss/reflections preserved, iOS runs offline.
+
+### C.6 De-band the piece materials on web/iOS (VERIFIED)
+
+Same root cause + fix as desktop A.5, ported into the shared `chess3d-renderer.js`: `debandPieceMaterial()`
+flattens the striped roughness (`roughnessMap=null`, `roughness=0.4`, `metalness=0`) and softens the
+albedo grain toward the per-material mean via an `onBeforeCompile` patch
+(`diffuseColor.rgb = mix(uGrainMean, diffuseColor.rgb, uGrainStrength)` after `<map_fragment>`). Applied
+to the glb `white`/`black` materials in `loadGlb`. Regenerated into both copies via `build.mjs`.
+
+### C.7 iOS blank-board fix — custom URL-scheme handler (VERIFIED; discovered during verification)
+
+**Symptom:** on iOS the 3D board rendered **blank navy** (`0x1a2a3a` = `loadEnvironment()`'s catch
+fallback). Instrumenting `chess3d-host.html` to surface the JS console showed:
+`papermill HDR load failed … Load failed` and `chess.glb not found`. **Root cause:** WKWebView blocks
+`XMLHttpRequest`/`fetch` of `file://` resources even when the page is loaded via
+`loadFileURL(allowingReadAccessToURL:)`, so three.js's GLTFLoader/RGBELoader can't fetch the glb/HDRs.
+Pre-existing, unrelated to the de-band (reproduced on the committed bundle) and to the EffectComposer
+(reproduced with post disabled).
+
+**Fix (iOS platform glue):** the KVC `allowFileAccessFromFileURLs` pref is **not exposed in
+Kotlin/Native** (`setValue(_:forKey:)` isn't bound on `NSObject`), so instead register a
+`WKURLSchemeHandler` (`BundleAssetSchemeHandler` in `IosBoard3D.kt`) on the config for a custom
+`chessasset://` scheme and load the host via that scheme (`WKWebViewChessRenderer.attach`). Custom
+schemes are not subject to the `file://` XHR restriction, so the loaders work. Note the two
+`webView(…)` protocol overrides need `@kotlinx.cinterop.ObjCSignatureOverride` (same Kotlin signature),
+and bundle bytes are read with `NSFileManager.contentsAtPath` (`NSData.dataWithContentsOfFile` isn't
+bound). **Verified:** `tools/ios_3d_screenshot.sh` now renders the full board with de-banded pieces.
+
+> Follow-up (out of scope here): the Part C web/iOS bloom (`BLOOM_STRENGTH=0.7`, `THRESHOLD=0.6`) reads
+> as a strong central blow-out on the iOS capture — likely wants toning down to match Android.
+
+---
+
+## 3. Verification matrix (must all pass before "done")
+
+| Check | Command |
+|---|---|
+| All targets build | `./gradlew :androidApp:assembleDebug :app:assembleAndroidDeviceTest :app:check :app:desktopJar :app:packageDistributionForCurrentOS :app:wasmJsBrowserDistribution` |
+| Desktop eyeball + asserts | `./gradlew :app:desktopTest --tests "*DesktopRendererSmokeTest*" -Dchess3d.smoke=true` → inspect `app/build/chess3d-*.png` |
+| Desktop 3D unit tests intact | `./gradlew :app:desktopTest --tests "*board3d*"` |
+| Desktop perf | `./gradlew :app:desktopTest --tests "*VulkanFpsBenchmark*" -Dchess3d.bench=true` |
+| Web | `./gradlew :app:wasmJsBrowserDevelopmentRun` (browser) |
+| iOS/web shared renderer eyeball | `tools/ios_3d_screenshot.sh` → `build/ios-3d-screenshot.png` |
+| Apple targets | iOS/macOS build + simulator tests (CI `apple` job) |
+
+## 4. Guardrails (do not violate)
+- No Android changes; no `commonMain` API changes; no changes to the
+  `Chess3DBoardRenderer`/`Board3DScene` abstraction; no wgpu4k changes.
+- Desktop AA stays as-is (8× MSAA + SSAA) — only web needed AA work.
+- Generated three.js copies are produced **only** by `build.mjs`.
+
+## 5. Commit sequence
+1. `feat(3d/desktop): glossier pieces + AO/contact grounding + warmer tone (shader tuning)` — Part A.
+2. `feat(3d/desktop): HDR bloom post pipeline` — Part B (B-step 1 then B-step 2 may be two commits).
+3. `feat(3d/web): EffectComposer AA + bloom for web/iOS parity` — Part C (JS source + both regenerated
+   copies in one commit).

--- a/iosApp/iosApp/Resources/chess3d-bundle.js
+++ b/iosApp/iosApp/Resources/chess3d-bundle.js
@@ -19375,6 +19375,13 @@ void main() {
       });
     }
   }
+  var RawShaderMaterial = class extends ShaderMaterial {
+    constructor(parameters) {
+      super(parameters);
+      this.isRawShaderMaterial = true;
+      this.type = "RawShaderMaterial";
+    }
+  };
   var MeshStandardMaterial = class extends Material {
     constructor(parameters) {
       super();
@@ -21189,6 +21196,47 @@ void main() {
       scope.manager.itemStart(url);
     }
   };
+  var Clock = class {
+    constructor(autoStart = true) {
+      this.autoStart = autoStart;
+      this.startTime = 0;
+      this.oldTime = 0;
+      this.elapsedTime = 0;
+      this.running = false;
+    }
+    start() {
+      this.startTime = now();
+      this.oldTime = this.startTime;
+      this.elapsedTime = 0;
+      this.running = true;
+    }
+    stop() {
+      this.getElapsedTime();
+      this.running = false;
+      this.autoStart = false;
+    }
+    getElapsedTime() {
+      this.getDelta();
+      return this.elapsedTime;
+    }
+    getDelta() {
+      let diff = 0;
+      if (this.autoStart && !this.running) {
+        this.start();
+        return 0;
+      }
+      if (this.running) {
+        const newTime = now();
+        diff = (newTime - this.oldTime) / 1e3;
+        this.oldTime = newTime;
+        this.elapsedTime += diff;
+      }
+      return diff;
+    }
+  };
+  function now() {
+    return performance.now();
+  }
   var _RESERVED_CHARS_RE = "\\[\\]\\.:\\/";
   var _reservedRe = new RegExp("[" + _RESERVED_CHARS_RE + "]", "g");
   var _wordChar = "[^" + _RESERVED_CHARS_RE + "]";
@@ -24448,8 +24496,1369 @@ void main() {
     return material;
   }
 
+  // node_modules/three/examples/jsm/shaders/CopyShader.js
+  var CopyShader = {
+    name: "CopyShader",
+    uniforms: {
+      "tDiffuse": { value: null },
+      "opacity": { value: 1 }
+    },
+    vertexShader: (
+      /* glsl */
+      `
+
+		varying vec2 vUv;
+
+		void main() {
+
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+		}`
+    ),
+    fragmentShader: (
+      /* glsl */
+      `
+
+		uniform float opacity;
+
+		uniform sampler2D tDiffuse;
+
+		varying vec2 vUv;
+
+		void main() {
+
+			vec4 texel = texture2D( tDiffuse, vUv );
+			gl_FragColor = opacity * texel;
+
+
+		}`
+    )
+  };
+
+  // node_modules/three/examples/jsm/postprocessing/Pass.js
+  var Pass = class {
+    constructor() {
+      this.isPass = true;
+      this.enabled = true;
+      this.needsSwap = true;
+      this.clear = false;
+      this.renderToScreen = false;
+    }
+    setSize() {
+    }
+    render() {
+      console.error("THREE.Pass: .render() must be implemented in derived pass.");
+    }
+    dispose() {
+    }
+  };
+  var _camera = new OrthographicCamera(-1, 1, 1, -1, 0, 1);
+  var FullscreenTriangleGeometry = class extends BufferGeometry {
+    constructor() {
+      super();
+      this.setAttribute("position", new Float32BufferAttribute([-1, 3, 0, -1, -1, 0, 3, -1, 0], 3));
+      this.setAttribute("uv", new Float32BufferAttribute([0, 2, 0, 0, 2, 0], 2));
+    }
+  };
+  var _geometry = new FullscreenTriangleGeometry();
+  var FullScreenQuad = class {
+    constructor(material) {
+      this._mesh = new Mesh(_geometry, material);
+    }
+    dispose() {
+      this._mesh.geometry.dispose();
+    }
+    render(renderer2) {
+      renderer2.render(this._mesh, _camera);
+    }
+    get material() {
+      return this._mesh.material;
+    }
+    set material(value) {
+      this._mesh.material = value;
+    }
+  };
+
+  // node_modules/three/examples/jsm/postprocessing/ShaderPass.js
+  var ShaderPass = class extends Pass {
+    constructor(shader, textureID) {
+      super();
+      this.textureID = textureID !== void 0 ? textureID : "tDiffuse";
+      if (shader instanceof ShaderMaterial) {
+        this.uniforms = shader.uniforms;
+        this.material = shader;
+      } else if (shader) {
+        this.uniforms = UniformsUtils.clone(shader.uniforms);
+        this.material = new ShaderMaterial({
+          name: shader.name !== void 0 ? shader.name : "unspecified",
+          defines: Object.assign({}, shader.defines),
+          uniforms: this.uniforms,
+          vertexShader: shader.vertexShader,
+          fragmentShader: shader.fragmentShader
+        });
+      }
+      this.fsQuad = new FullScreenQuad(this.material);
+    }
+    render(renderer2, writeBuffer, readBuffer) {
+      if (this.uniforms[this.textureID]) {
+        this.uniforms[this.textureID].value = readBuffer.texture;
+      }
+      this.fsQuad.material = this.material;
+      if (this.renderToScreen) {
+        renderer2.setRenderTarget(null);
+        this.fsQuad.render(renderer2);
+      } else {
+        renderer2.setRenderTarget(writeBuffer);
+        if (this.clear) renderer2.clear(renderer2.autoClearColor, renderer2.autoClearDepth, renderer2.autoClearStencil);
+        this.fsQuad.render(renderer2);
+      }
+    }
+    dispose() {
+      this.material.dispose();
+      this.fsQuad.dispose();
+    }
+  };
+
+  // node_modules/three/examples/jsm/postprocessing/MaskPass.js
+  var MaskPass = class extends Pass {
+    constructor(scene2, camera2) {
+      super();
+      this.scene = scene2;
+      this.camera = camera2;
+      this.clear = true;
+      this.needsSwap = false;
+      this.inverse = false;
+    }
+    render(renderer2, writeBuffer, readBuffer) {
+      const context = renderer2.getContext();
+      const state = renderer2.state;
+      state.buffers.color.setMask(false);
+      state.buffers.depth.setMask(false);
+      state.buffers.color.setLocked(true);
+      state.buffers.depth.setLocked(true);
+      let writeValue, clearValue;
+      if (this.inverse) {
+        writeValue = 0;
+        clearValue = 1;
+      } else {
+        writeValue = 1;
+        clearValue = 0;
+      }
+      state.buffers.stencil.setTest(true);
+      state.buffers.stencil.setOp(context.REPLACE, context.REPLACE, context.REPLACE);
+      state.buffers.stencil.setFunc(context.ALWAYS, writeValue, 4294967295);
+      state.buffers.stencil.setClear(clearValue);
+      state.buffers.stencil.setLocked(true);
+      renderer2.setRenderTarget(readBuffer);
+      if (this.clear) renderer2.clear();
+      renderer2.render(this.scene, this.camera);
+      renderer2.setRenderTarget(writeBuffer);
+      if (this.clear) renderer2.clear();
+      renderer2.render(this.scene, this.camera);
+      state.buffers.color.setLocked(false);
+      state.buffers.depth.setLocked(false);
+      state.buffers.color.setMask(true);
+      state.buffers.depth.setMask(true);
+      state.buffers.stencil.setLocked(false);
+      state.buffers.stencil.setFunc(context.EQUAL, 1, 4294967295);
+      state.buffers.stencil.setOp(context.KEEP, context.KEEP, context.KEEP);
+      state.buffers.stencil.setLocked(true);
+    }
+  };
+  var ClearMaskPass = class extends Pass {
+    constructor() {
+      super();
+      this.needsSwap = false;
+    }
+    render(renderer2) {
+      renderer2.state.buffers.stencil.setLocked(false);
+      renderer2.state.buffers.stencil.setTest(false);
+    }
+  };
+
+  // node_modules/three/examples/jsm/postprocessing/EffectComposer.js
+  var EffectComposer = class {
+    constructor(renderer2, renderTarget) {
+      this.renderer = renderer2;
+      this._pixelRatio = renderer2.getPixelRatio();
+      if (renderTarget === void 0) {
+        const size = renderer2.getSize(new Vector2());
+        this._width = size.width;
+        this._height = size.height;
+        renderTarget = new WebGLRenderTarget(this._width * this._pixelRatio, this._height * this._pixelRatio, { type: HalfFloatType });
+        renderTarget.texture.name = "EffectComposer.rt1";
+      } else {
+        this._width = renderTarget.width;
+        this._height = renderTarget.height;
+      }
+      this.renderTarget1 = renderTarget;
+      this.renderTarget2 = renderTarget.clone();
+      this.renderTarget2.texture.name = "EffectComposer.rt2";
+      this.writeBuffer = this.renderTarget1;
+      this.readBuffer = this.renderTarget2;
+      this.renderToScreen = true;
+      this.passes = [];
+      this.copyPass = new ShaderPass(CopyShader);
+      this.copyPass.material.blending = NoBlending;
+      this.clock = new Clock();
+    }
+    swapBuffers() {
+      const tmp = this.readBuffer;
+      this.readBuffer = this.writeBuffer;
+      this.writeBuffer = tmp;
+    }
+    addPass(pass) {
+      this.passes.push(pass);
+      pass.setSize(this._width * this._pixelRatio, this._height * this._pixelRatio);
+    }
+    insertPass(pass, index) {
+      this.passes.splice(index, 0, pass);
+      pass.setSize(this._width * this._pixelRatio, this._height * this._pixelRatio);
+    }
+    removePass(pass) {
+      const index = this.passes.indexOf(pass);
+      if (index !== -1) {
+        this.passes.splice(index, 1);
+      }
+    }
+    isLastEnabledPass(passIndex) {
+      for (let i = passIndex + 1; i < this.passes.length; i++) {
+        if (this.passes[i].enabled) {
+          return false;
+        }
+      }
+      return true;
+    }
+    render(deltaTime) {
+      if (deltaTime === void 0) {
+        deltaTime = this.clock.getDelta();
+      }
+      const currentRenderTarget = this.renderer.getRenderTarget();
+      let maskActive = false;
+      for (let i = 0, il = this.passes.length; i < il; i++) {
+        const pass = this.passes[i];
+        if (pass.enabled === false) continue;
+        pass.renderToScreen = this.renderToScreen && this.isLastEnabledPass(i);
+        pass.render(this.renderer, this.writeBuffer, this.readBuffer, deltaTime, maskActive);
+        if (pass.needsSwap) {
+          if (maskActive) {
+            const context = this.renderer.getContext();
+            const stencil = this.renderer.state.buffers.stencil;
+            stencil.setFunc(context.NOTEQUAL, 1, 4294967295);
+            this.copyPass.render(this.renderer, this.writeBuffer, this.readBuffer, deltaTime);
+            stencil.setFunc(context.EQUAL, 1, 4294967295);
+          }
+          this.swapBuffers();
+        }
+        if (MaskPass !== void 0) {
+          if (pass instanceof MaskPass) {
+            maskActive = true;
+          } else if (pass instanceof ClearMaskPass) {
+            maskActive = false;
+          }
+        }
+      }
+      this.renderer.setRenderTarget(currentRenderTarget);
+    }
+    reset(renderTarget) {
+      if (renderTarget === void 0) {
+        const size = this.renderer.getSize(new Vector2());
+        this._pixelRatio = this.renderer.getPixelRatio();
+        this._width = size.width;
+        this._height = size.height;
+        renderTarget = this.renderTarget1.clone();
+        renderTarget.setSize(this._width * this._pixelRatio, this._height * this._pixelRatio);
+      }
+      this.renderTarget1.dispose();
+      this.renderTarget2.dispose();
+      this.renderTarget1 = renderTarget;
+      this.renderTarget2 = renderTarget.clone();
+      this.writeBuffer = this.renderTarget1;
+      this.readBuffer = this.renderTarget2;
+    }
+    setSize(width, height) {
+      this._width = width;
+      this._height = height;
+      const effectiveWidth = this._width * this._pixelRatio;
+      const effectiveHeight = this._height * this._pixelRatio;
+      this.renderTarget1.setSize(effectiveWidth, effectiveHeight);
+      this.renderTarget2.setSize(effectiveWidth, effectiveHeight);
+      for (let i = 0; i < this.passes.length; i++) {
+        this.passes[i].setSize(effectiveWidth, effectiveHeight);
+      }
+    }
+    setPixelRatio(pixelRatio) {
+      this._pixelRatio = pixelRatio;
+      this.setSize(this._width, this._height);
+    }
+    dispose() {
+      this.renderTarget1.dispose();
+      this.renderTarget2.dispose();
+      this.copyPass.dispose();
+    }
+  };
+
+  // node_modules/three/examples/jsm/postprocessing/RenderPass.js
+  var RenderPass = class extends Pass {
+    constructor(scene2, camera2, overrideMaterial = null, clearColor = null, clearAlpha = null) {
+      super();
+      this.scene = scene2;
+      this.camera = camera2;
+      this.overrideMaterial = overrideMaterial;
+      this.clearColor = clearColor;
+      this.clearAlpha = clearAlpha;
+      this.clear = true;
+      this.clearDepth = false;
+      this.needsSwap = false;
+      this._oldClearColor = new Color();
+    }
+    render(renderer2, writeBuffer, readBuffer) {
+      const oldAutoClear = renderer2.autoClear;
+      renderer2.autoClear = false;
+      let oldClearAlpha, oldOverrideMaterial;
+      if (this.overrideMaterial !== null) {
+        oldOverrideMaterial = this.scene.overrideMaterial;
+        this.scene.overrideMaterial = this.overrideMaterial;
+      }
+      if (this.clearColor !== null) {
+        renderer2.getClearColor(this._oldClearColor);
+        renderer2.setClearColor(this.clearColor, renderer2.getClearAlpha());
+      }
+      if (this.clearAlpha !== null) {
+        oldClearAlpha = renderer2.getClearAlpha();
+        renderer2.setClearAlpha(this.clearAlpha);
+      }
+      if (this.clearDepth == true) {
+        renderer2.clearDepth();
+      }
+      renderer2.setRenderTarget(this.renderToScreen ? null : readBuffer);
+      if (this.clear === true) {
+        renderer2.clear(renderer2.autoClearColor, renderer2.autoClearDepth, renderer2.autoClearStencil);
+      }
+      renderer2.render(this.scene, this.camera);
+      if (this.clearColor !== null) {
+        renderer2.setClearColor(this._oldClearColor);
+      }
+      if (this.clearAlpha !== null) {
+        renderer2.setClearAlpha(oldClearAlpha);
+      }
+      if (this.overrideMaterial !== null) {
+        this.scene.overrideMaterial = oldOverrideMaterial;
+      }
+      renderer2.autoClear = oldAutoClear;
+    }
+  };
+
+  // node_modules/three/examples/jsm/shaders/LuminosityHighPassShader.js
+  var LuminosityHighPassShader = {
+    name: "LuminosityHighPassShader",
+    shaderID: "luminosityHighPass",
+    uniforms: {
+      "tDiffuse": { value: null },
+      "luminosityThreshold": { value: 1 },
+      "smoothWidth": { value: 1 },
+      "defaultColor": { value: new Color(0) },
+      "defaultOpacity": { value: 0 }
+    },
+    vertexShader: (
+      /* glsl */
+      `
+
+		varying vec2 vUv;
+
+		void main() {
+
+			vUv = uv;
+
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+		}`
+    ),
+    fragmentShader: (
+      /* glsl */
+      `
+
+		uniform sampler2D tDiffuse;
+		uniform vec3 defaultColor;
+		uniform float defaultOpacity;
+		uniform float luminosityThreshold;
+		uniform float smoothWidth;
+
+		varying vec2 vUv;
+
+		void main() {
+
+			vec4 texel = texture2D( tDiffuse, vUv );
+
+			float v = luminance( texel.xyz );
+
+			vec4 outputColor = vec4( defaultColor.rgb, defaultOpacity );
+
+			float alpha = smoothstep( luminosityThreshold, luminosityThreshold + smoothWidth, v );
+
+			gl_FragColor = mix( outputColor, texel, alpha );
+
+		}`
+    )
+  };
+
+  // node_modules/three/examples/jsm/postprocessing/UnrealBloomPass.js
+  var UnrealBloomPass = class _UnrealBloomPass extends Pass {
+    constructor(resolution, strength, radius, threshold) {
+      super();
+      this.strength = strength !== void 0 ? strength : 1;
+      this.radius = radius;
+      this.threshold = threshold;
+      this.resolution = resolution !== void 0 ? new Vector2(resolution.x, resolution.y) : new Vector2(256, 256);
+      this.clearColor = new Color(0, 0, 0);
+      this.renderTargetsHorizontal = [];
+      this.renderTargetsVertical = [];
+      this.nMips = 5;
+      let resx = Math.round(this.resolution.x / 2);
+      let resy = Math.round(this.resolution.y / 2);
+      this.renderTargetBright = new WebGLRenderTarget(resx, resy, { type: HalfFloatType });
+      this.renderTargetBright.texture.name = "UnrealBloomPass.bright";
+      this.renderTargetBright.texture.generateMipmaps = false;
+      for (let i = 0; i < this.nMips; i++) {
+        const renderTargetHorizontal = new WebGLRenderTarget(resx, resy, { type: HalfFloatType });
+        renderTargetHorizontal.texture.name = "UnrealBloomPass.h" + i;
+        renderTargetHorizontal.texture.generateMipmaps = false;
+        this.renderTargetsHorizontal.push(renderTargetHorizontal);
+        const renderTargetVertical = new WebGLRenderTarget(resx, resy, { type: HalfFloatType });
+        renderTargetVertical.texture.name = "UnrealBloomPass.v" + i;
+        renderTargetVertical.texture.generateMipmaps = false;
+        this.renderTargetsVertical.push(renderTargetVertical);
+        resx = Math.round(resx / 2);
+        resy = Math.round(resy / 2);
+      }
+      const highPassShader = LuminosityHighPassShader;
+      this.highPassUniforms = UniformsUtils.clone(highPassShader.uniforms);
+      this.highPassUniforms["luminosityThreshold"].value = threshold;
+      this.highPassUniforms["smoothWidth"].value = 0.01;
+      this.materialHighPassFilter = new ShaderMaterial({
+        uniforms: this.highPassUniforms,
+        vertexShader: highPassShader.vertexShader,
+        fragmentShader: highPassShader.fragmentShader
+      });
+      this.separableBlurMaterials = [];
+      const kernelSizeArray = [3, 5, 7, 9, 11];
+      resx = Math.round(this.resolution.x / 2);
+      resy = Math.round(this.resolution.y / 2);
+      for (let i = 0; i < this.nMips; i++) {
+        this.separableBlurMaterials.push(this.getSeperableBlurMaterial(kernelSizeArray[i]));
+        this.separableBlurMaterials[i].uniforms["invSize"].value = new Vector2(1 / resx, 1 / resy);
+        resx = Math.round(resx / 2);
+        resy = Math.round(resy / 2);
+      }
+      this.compositeMaterial = this.getCompositeMaterial(this.nMips);
+      this.compositeMaterial.uniforms["blurTexture1"].value = this.renderTargetsVertical[0].texture;
+      this.compositeMaterial.uniforms["blurTexture2"].value = this.renderTargetsVertical[1].texture;
+      this.compositeMaterial.uniforms["blurTexture3"].value = this.renderTargetsVertical[2].texture;
+      this.compositeMaterial.uniforms["blurTexture4"].value = this.renderTargetsVertical[3].texture;
+      this.compositeMaterial.uniforms["blurTexture5"].value = this.renderTargetsVertical[4].texture;
+      this.compositeMaterial.uniforms["bloomStrength"].value = strength;
+      this.compositeMaterial.uniforms["bloomRadius"].value = 0.1;
+      const bloomFactors = [1, 0.8, 0.6, 0.4, 0.2];
+      this.compositeMaterial.uniforms["bloomFactors"].value = bloomFactors;
+      this.bloomTintColors = [new Vector3(1, 1, 1), new Vector3(1, 1, 1), new Vector3(1, 1, 1), new Vector3(1, 1, 1), new Vector3(1, 1, 1)];
+      this.compositeMaterial.uniforms["bloomTintColors"].value = this.bloomTintColors;
+      const copyShader = CopyShader;
+      this.copyUniforms = UniformsUtils.clone(copyShader.uniforms);
+      this.blendMaterial = new ShaderMaterial({
+        uniforms: this.copyUniforms,
+        vertexShader: copyShader.vertexShader,
+        fragmentShader: copyShader.fragmentShader,
+        blending: AdditiveBlending,
+        depthTest: false,
+        depthWrite: false,
+        transparent: true
+      });
+      this.enabled = true;
+      this.needsSwap = false;
+      this._oldClearColor = new Color();
+      this.oldClearAlpha = 1;
+      this.basic = new MeshBasicMaterial();
+      this.fsQuad = new FullScreenQuad(null);
+    }
+    dispose() {
+      for (let i = 0; i < this.renderTargetsHorizontal.length; i++) {
+        this.renderTargetsHorizontal[i].dispose();
+      }
+      for (let i = 0; i < this.renderTargetsVertical.length; i++) {
+        this.renderTargetsVertical[i].dispose();
+      }
+      this.renderTargetBright.dispose();
+      for (let i = 0; i < this.separableBlurMaterials.length; i++) {
+        this.separableBlurMaterials[i].dispose();
+      }
+      this.compositeMaterial.dispose();
+      this.blendMaterial.dispose();
+      this.basic.dispose();
+      this.fsQuad.dispose();
+    }
+    setSize(width, height) {
+      let resx = Math.round(width / 2);
+      let resy = Math.round(height / 2);
+      this.renderTargetBright.setSize(resx, resy);
+      for (let i = 0; i < this.nMips; i++) {
+        this.renderTargetsHorizontal[i].setSize(resx, resy);
+        this.renderTargetsVertical[i].setSize(resx, resy);
+        this.separableBlurMaterials[i].uniforms["invSize"].value = new Vector2(1 / resx, 1 / resy);
+        resx = Math.round(resx / 2);
+        resy = Math.round(resy / 2);
+      }
+    }
+    render(renderer2, writeBuffer, readBuffer, deltaTime, maskActive) {
+      renderer2.getClearColor(this._oldClearColor);
+      this.oldClearAlpha = renderer2.getClearAlpha();
+      const oldAutoClear = renderer2.autoClear;
+      renderer2.autoClear = false;
+      renderer2.setClearColor(this.clearColor, 0);
+      if (maskActive) renderer2.state.buffers.stencil.setTest(false);
+      if (this.renderToScreen) {
+        this.fsQuad.material = this.basic;
+        this.basic.map = readBuffer.texture;
+        renderer2.setRenderTarget(null);
+        renderer2.clear();
+        this.fsQuad.render(renderer2);
+      }
+      this.highPassUniforms["tDiffuse"].value = readBuffer.texture;
+      this.highPassUniforms["luminosityThreshold"].value = this.threshold;
+      this.fsQuad.material = this.materialHighPassFilter;
+      renderer2.setRenderTarget(this.renderTargetBright);
+      renderer2.clear();
+      this.fsQuad.render(renderer2);
+      let inputRenderTarget = this.renderTargetBright;
+      for (let i = 0; i < this.nMips; i++) {
+        this.fsQuad.material = this.separableBlurMaterials[i];
+        this.separableBlurMaterials[i].uniforms["colorTexture"].value = inputRenderTarget.texture;
+        this.separableBlurMaterials[i].uniforms["direction"].value = _UnrealBloomPass.BlurDirectionX;
+        renderer2.setRenderTarget(this.renderTargetsHorizontal[i]);
+        renderer2.clear();
+        this.fsQuad.render(renderer2);
+        this.separableBlurMaterials[i].uniforms["colorTexture"].value = this.renderTargetsHorizontal[i].texture;
+        this.separableBlurMaterials[i].uniforms["direction"].value = _UnrealBloomPass.BlurDirectionY;
+        renderer2.setRenderTarget(this.renderTargetsVertical[i]);
+        renderer2.clear();
+        this.fsQuad.render(renderer2);
+        inputRenderTarget = this.renderTargetsVertical[i];
+      }
+      this.fsQuad.material = this.compositeMaterial;
+      this.compositeMaterial.uniforms["bloomStrength"].value = this.strength;
+      this.compositeMaterial.uniforms["bloomRadius"].value = this.radius;
+      this.compositeMaterial.uniforms["bloomTintColors"].value = this.bloomTintColors;
+      renderer2.setRenderTarget(this.renderTargetsHorizontal[0]);
+      renderer2.clear();
+      this.fsQuad.render(renderer2);
+      this.fsQuad.material = this.blendMaterial;
+      this.copyUniforms["tDiffuse"].value = this.renderTargetsHorizontal[0].texture;
+      if (maskActive) renderer2.state.buffers.stencil.setTest(true);
+      if (this.renderToScreen) {
+        renderer2.setRenderTarget(null);
+        this.fsQuad.render(renderer2);
+      } else {
+        renderer2.setRenderTarget(readBuffer);
+        this.fsQuad.render(renderer2);
+      }
+      renderer2.setClearColor(this._oldClearColor, this.oldClearAlpha);
+      renderer2.autoClear = oldAutoClear;
+    }
+    getSeperableBlurMaterial(kernelRadius) {
+      const coefficients = [];
+      for (let i = 0; i < kernelRadius; i++) {
+        coefficients.push(0.39894 * Math.exp(-0.5 * i * i / (kernelRadius * kernelRadius)) / kernelRadius);
+      }
+      return new ShaderMaterial({
+        defines: {
+          "KERNEL_RADIUS": kernelRadius
+        },
+        uniforms: {
+          "colorTexture": { value: null },
+          "invSize": { value: new Vector2(0.5, 0.5) },
+          // inverse texture size
+          "direction": { value: new Vector2(0.5, 0.5) },
+          "gaussianCoefficients": { value: coefficients }
+          // precomputed Gaussian coefficients
+        },
+        vertexShader: `varying vec2 vUv;
+				void main() {
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				}`,
+        fragmentShader: `#include <common>
+				varying vec2 vUv;
+				uniform sampler2D colorTexture;
+				uniform vec2 invSize;
+				uniform vec2 direction;
+				uniform float gaussianCoefficients[KERNEL_RADIUS];
+
+				void main() {
+					float weightSum = gaussianCoefficients[0];
+					vec3 diffuseSum = texture2D( colorTexture, vUv ).rgb * weightSum;
+					for( int i = 1; i < KERNEL_RADIUS; i ++ ) {
+						float x = float(i);
+						float w = gaussianCoefficients[i];
+						vec2 uvOffset = direction * invSize * x;
+						vec3 sample1 = texture2D( colorTexture, vUv + uvOffset ).rgb;
+						vec3 sample2 = texture2D( colorTexture, vUv - uvOffset ).rgb;
+						diffuseSum += (sample1 + sample2) * w;
+						weightSum += 2.0 * w;
+					}
+					gl_FragColor = vec4(diffuseSum/weightSum, 1.0);
+				}`
+      });
+    }
+    getCompositeMaterial(nMips) {
+      return new ShaderMaterial({
+        defines: {
+          "NUM_MIPS": nMips
+        },
+        uniforms: {
+          "blurTexture1": { value: null },
+          "blurTexture2": { value: null },
+          "blurTexture3": { value: null },
+          "blurTexture4": { value: null },
+          "blurTexture5": { value: null },
+          "bloomStrength": { value: 1 },
+          "bloomFactors": { value: null },
+          "bloomTintColors": { value: null },
+          "bloomRadius": { value: 0 }
+        },
+        vertexShader: `varying vec2 vUv;
+				void main() {
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+				}`,
+        fragmentShader: `varying vec2 vUv;
+				uniform sampler2D blurTexture1;
+				uniform sampler2D blurTexture2;
+				uniform sampler2D blurTexture3;
+				uniform sampler2D blurTexture4;
+				uniform sampler2D blurTexture5;
+				uniform float bloomStrength;
+				uniform float bloomRadius;
+				uniform float bloomFactors[NUM_MIPS];
+				uniform vec3 bloomTintColors[NUM_MIPS];
+
+				float lerpBloomFactor(const in float factor) {
+					float mirrorFactor = 1.2 - factor;
+					return mix(factor, mirrorFactor, bloomRadius);
+				}
+
+				void main() {
+					gl_FragColor = bloomStrength * ( lerpBloomFactor(bloomFactors[0]) * vec4(bloomTintColors[0], 1.0) * texture2D(blurTexture1, vUv) +
+						lerpBloomFactor(bloomFactors[1]) * vec4(bloomTintColors[1], 1.0) * texture2D(blurTexture2, vUv) +
+						lerpBloomFactor(bloomFactors[2]) * vec4(bloomTintColors[2], 1.0) * texture2D(blurTexture3, vUv) +
+						lerpBloomFactor(bloomFactors[3]) * vec4(bloomTintColors[3], 1.0) * texture2D(blurTexture4, vUv) +
+						lerpBloomFactor(bloomFactors[4]) * vec4(bloomTintColors[4], 1.0) * texture2D(blurTexture5, vUv) );
+				}`
+      });
+    }
+  };
+  UnrealBloomPass.BlurDirectionX = new Vector2(1, 0);
+  UnrealBloomPass.BlurDirectionY = new Vector2(0, 1);
+
+  // node_modules/three/examples/jsm/shaders/SMAAShader.js
+  var SMAAEdgesShader = {
+    name: "SMAAEdgesShader",
+    defines: {
+      "SMAA_THRESHOLD": "0.1"
+    },
+    uniforms: {
+      "tDiffuse": { value: null },
+      "resolution": { value: new Vector2(1 / 1024, 1 / 512) }
+    },
+    vertexShader: (
+      /* glsl */
+      `
+
+		uniform vec2 resolution;
+
+		varying vec2 vUv;
+		varying vec4 vOffset[ 3 ];
+
+		void SMAAEdgeDetectionVS( vec2 texcoord ) {
+			vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0,  1.0 ); // WebGL port note: Changed sign in W component
+			vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4(  1.0, 0.0, 0.0, -1.0 ); // WebGL port note: Changed sign in W component
+			vOffset[ 2 ] = texcoord.xyxy + resolution.xyxy * vec4( -2.0, 0.0, 0.0,  2.0 ); // WebGL port note: Changed sign in W component
+		}
+
+		void main() {
+
+			vUv = uv;
+
+			SMAAEdgeDetectionVS( vUv );
+
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+		}`
+    ),
+    fragmentShader: (
+      /* glsl */
+      `
+
+		uniform sampler2D tDiffuse;
+
+		varying vec2 vUv;
+		varying vec4 vOffset[ 3 ];
+
+		vec4 SMAAColorEdgeDetectionPS( vec2 texcoord, vec4 offset[3], sampler2D colorTex ) {
+			vec2 threshold = vec2( SMAA_THRESHOLD, SMAA_THRESHOLD );
+
+			// Calculate color deltas:
+			vec4 delta;
+			vec3 C = texture2D( colorTex, texcoord ).rgb;
+
+			vec3 Cleft = texture2D( colorTex, offset[0].xy ).rgb;
+			vec3 t = abs( C - Cleft );
+			delta.x = max( max( t.r, t.g ), t.b );
+
+			vec3 Ctop = texture2D( colorTex, offset[0].zw ).rgb;
+			t = abs( C - Ctop );
+			delta.y = max( max( t.r, t.g ), t.b );
+
+			// We do the usual threshold:
+			vec2 edges = step( threshold, delta.xy );
+
+			// Then discard if there is no edge:
+			if ( dot( edges, vec2( 1.0, 1.0 ) ) == 0.0 )
+				discard;
+
+			// Calculate right and bottom deltas:
+			vec3 Cright = texture2D( colorTex, offset[1].xy ).rgb;
+			t = abs( C - Cright );
+			delta.z = max( max( t.r, t.g ), t.b );
+
+			vec3 Cbottom  = texture2D( colorTex, offset[1].zw ).rgb;
+			t = abs( C - Cbottom );
+			delta.w = max( max( t.r, t.g ), t.b );
+
+			// Calculate the maximum delta in the direct neighborhood:
+			float maxDelta = max( max( max( delta.x, delta.y ), delta.z ), delta.w );
+
+			// Calculate left-left and top-top deltas:
+			vec3 Cleftleft  = texture2D( colorTex, offset[2].xy ).rgb;
+			t = abs( C - Cleftleft );
+			delta.z = max( max( t.r, t.g ), t.b );
+
+			vec3 Ctoptop = texture2D( colorTex, offset[2].zw ).rgb;
+			t = abs( C - Ctoptop );
+			delta.w = max( max( t.r, t.g ), t.b );
+
+			// Calculate the final maximum delta:
+			maxDelta = max( max( maxDelta, delta.z ), delta.w );
+
+			// Local contrast adaptation in action:
+			edges.xy *= step( 0.5 * maxDelta, delta.xy );
+
+			return vec4( edges, 0.0, 0.0 );
+		}
+
+		void main() {
+
+			gl_FragColor = SMAAColorEdgeDetectionPS( vUv, vOffset, tDiffuse );
+
+		}`
+    )
+  };
+  var SMAAWeightsShader = {
+    name: "SMAAWeightsShader",
+    defines: {
+      "SMAA_MAX_SEARCH_STEPS": "8",
+      "SMAA_AREATEX_MAX_DISTANCE": "16",
+      "SMAA_AREATEX_PIXEL_SIZE": "( 1.0 / vec2( 160.0, 560.0 ) )",
+      "SMAA_AREATEX_SUBTEX_SIZE": "( 1.0 / 7.0 )"
+    },
+    uniforms: {
+      "tDiffuse": { value: null },
+      "tArea": { value: null },
+      "tSearch": { value: null },
+      "resolution": { value: new Vector2(1 / 1024, 1 / 512) }
+    },
+    vertexShader: (
+      /* glsl */
+      `
+
+		uniform vec2 resolution;
+
+		varying vec2 vUv;
+		varying vec4 vOffset[ 3 ];
+		varying vec2 vPixcoord;
+
+		void SMAABlendingWeightCalculationVS( vec2 texcoord ) {
+			vPixcoord = texcoord / resolution;
+
+			// We will use these offsets for the searches later on (see @PSEUDO_GATHER4):
+			vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.25, 0.125, 1.25, 0.125 ); // WebGL port note: Changed sign in Y and W components
+			vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( -0.125, 0.25, -0.125, -1.25 ); // WebGL port note: Changed sign in Y and W components
+
+			// And these for the searches, they indicate the ends of the loops:
+			vOffset[ 2 ] = vec4( vOffset[ 0 ].xz, vOffset[ 1 ].yw ) + vec4( -2.0, 2.0, -2.0, 2.0 ) * resolution.xxyy * float( SMAA_MAX_SEARCH_STEPS );
+
+		}
+
+		void main() {
+
+			vUv = uv;
+
+			SMAABlendingWeightCalculationVS( vUv );
+
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+		}`
+    ),
+    fragmentShader: (
+      /* glsl */
+      `
+
+		#define SMAASampleLevelZeroOffset( tex, coord, offset ) texture2D( tex, coord + float( offset ) * resolution, 0.0 )
+
+		uniform sampler2D tDiffuse;
+		uniform sampler2D tArea;
+		uniform sampler2D tSearch;
+		uniform vec2 resolution;
+
+		varying vec2 vUv;
+		varying vec4 vOffset[3];
+		varying vec2 vPixcoord;
+
+		#if __VERSION__ == 100
+		vec2 round( vec2 x ) {
+			return sign( x ) * floor( abs( x ) + 0.5 );
+		}
+		#endif
+
+		float SMAASearchLength( sampler2D searchTex, vec2 e, float bias, float scale ) {
+			// Not required if searchTex accesses are set to point:
+			// float2 SEARCH_TEX_PIXEL_SIZE = 1.0 / float2(66.0, 33.0);
+			// e = float2(bias, 0.0) + 0.5 * SEARCH_TEX_PIXEL_SIZE +
+			//     e * float2(scale, 1.0) * float2(64.0, 32.0) * SEARCH_TEX_PIXEL_SIZE;
+			e.r = bias + e.r * scale;
+			return 255.0 * texture2D( searchTex, e, 0.0 ).r;
+		}
+
+		float SMAASearchXLeft( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+			/**
+				* @PSEUDO_GATHER4
+				* This texcoord has been offset by (-0.25, -0.125) in the vertex shader to
+				* sample between edge, thus fetching four edges in a row.
+				* Sampling with different offsets in each direction allows to disambiguate
+				* which edges are active from the four fetched ones.
+				*/
+			vec2 e = vec2( 0.0, 1.0 );
+
+			for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+				e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+				texcoord -= vec2( 2.0, 0.0 ) * resolution;
+				if ( ! ( texcoord.x > end && e.g > 0.8281 && e.r == 0.0 ) ) break;
+			}
+
+			// We correct the previous (-0.25, -0.125) offset we applied:
+			texcoord.x += 0.25 * resolution.x;
+
+			// The searches are bias by 1, so adjust the coords accordingly:
+			texcoord.x += resolution.x;
+
+			// Disambiguate the length added by the last step:
+			texcoord.x += 2.0 * resolution.x; // Undo last step
+			texcoord.x -= resolution.x * SMAASearchLength(searchTex, e, 0.0, 0.5);
+
+			return texcoord.x;
+		}
+
+		float SMAASearchXRight( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+			vec2 e = vec2( 0.0, 1.0 );
+
+			for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+				e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+				texcoord += vec2( 2.0, 0.0 ) * resolution;
+				if ( ! ( texcoord.x < end && e.g > 0.8281 && e.r == 0.0 ) ) break;
+			}
+
+			texcoord.x -= 0.25 * resolution.x;
+			texcoord.x -= resolution.x;
+			texcoord.x -= 2.0 * resolution.x;
+			texcoord.x += resolution.x * SMAASearchLength( searchTex, e, 0.5, 0.5 );
+
+			return texcoord.x;
+		}
+
+		float SMAASearchYUp( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+			vec2 e = vec2( 1.0, 0.0 );
+
+			for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+				e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+				texcoord += vec2( 0.0, 2.0 ) * resolution; // WebGL port note: Changed sign
+				if ( ! ( texcoord.y > end && e.r > 0.8281 && e.g == 0.0 ) ) break;
+			}
+
+			texcoord.y -= 0.25 * resolution.y; // WebGL port note: Changed sign
+			texcoord.y -= resolution.y; // WebGL port note: Changed sign
+			texcoord.y -= 2.0 * resolution.y; // WebGL port note: Changed sign
+			texcoord.y += resolution.y * SMAASearchLength( searchTex, e.gr, 0.0, 0.5 ); // WebGL port note: Changed sign
+
+			return texcoord.y;
+		}
+
+		float SMAASearchYDown( sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end ) {
+			vec2 e = vec2( 1.0, 0.0 );
+
+			for ( int i = 0; i < SMAA_MAX_SEARCH_STEPS; i ++ ) { // WebGL port note: Changed while to for
+				e = texture2D( edgesTex, texcoord, 0.0 ).rg;
+				texcoord -= vec2( 0.0, 2.0 ) * resolution; // WebGL port note: Changed sign
+				if ( ! ( texcoord.y < end && e.r > 0.8281 && e.g == 0.0 ) ) break;
+			}
+
+			texcoord.y += 0.25 * resolution.y; // WebGL port note: Changed sign
+			texcoord.y += resolution.y; // WebGL port note: Changed sign
+			texcoord.y += 2.0 * resolution.y; // WebGL port note: Changed sign
+			texcoord.y -= resolution.y * SMAASearchLength( searchTex, e.gr, 0.5, 0.5 ); // WebGL port note: Changed sign
+
+			return texcoord.y;
+		}
+
+		vec2 SMAAArea( sampler2D areaTex, vec2 dist, float e1, float e2, float offset ) {
+			// Rounding prevents precision errors of bilinear filtering:
+			vec2 texcoord = float( SMAA_AREATEX_MAX_DISTANCE ) * round( 4.0 * vec2( e1, e2 ) ) + dist;
+
+			// We do a scale and bias for mapping to texel space:
+			texcoord = SMAA_AREATEX_PIXEL_SIZE * texcoord + ( 0.5 * SMAA_AREATEX_PIXEL_SIZE );
+
+			// Move to proper place, according to the subpixel offset:
+			texcoord.y += SMAA_AREATEX_SUBTEX_SIZE * offset;
+
+			return texture2D( areaTex, texcoord, 0.0 ).rg;
+		}
+
+		vec4 SMAABlendingWeightCalculationPS( vec2 texcoord, vec2 pixcoord, vec4 offset[ 3 ], sampler2D edgesTex, sampler2D areaTex, sampler2D searchTex, ivec4 subsampleIndices ) {
+			vec4 weights = vec4( 0.0, 0.0, 0.0, 0.0 );
+
+			vec2 e = texture2D( edgesTex, texcoord ).rg;
+
+			if ( e.g > 0.0 ) { // Edge at north
+				vec2 d;
+
+				// Find the distance to the left:
+				vec2 coords;
+				coords.x = SMAASearchXLeft( edgesTex, searchTex, offset[ 0 ].xy, offset[ 2 ].x );
+				coords.y = offset[ 1 ].y; // offset[1].y = texcoord.y - 0.25 * resolution.y (@CROSSING_OFFSET)
+				d.x = coords.x;
+
+				// Now fetch the left crossing edges, two at a time using bilinear
+				// filtering. Sampling at -0.25 (see @CROSSING_OFFSET) enables to
+				// discern what value each edge has:
+				float e1 = texture2D( edgesTex, coords, 0.0 ).r;
+
+				// Find the distance to the right:
+				coords.x = SMAASearchXRight( edgesTex, searchTex, offset[ 0 ].zw, offset[ 2 ].y );
+				d.y = coords.x;
+
+				// We want the distances to be in pixel units (doing this here allow to
+				// better interleave arithmetic and memory accesses):
+				d = d / resolution.x - pixcoord.x;
+
+				// SMAAArea below needs a sqrt, as the areas texture is compressed
+				// quadratically:
+				vec2 sqrt_d = sqrt( abs( d ) );
+
+				// Fetch the right crossing edges:
+				coords.y -= 1.0 * resolution.y; // WebGL port note: Added
+				float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 1, 0 ) ).r;
+
+				// Ok, we know how this pattern looks like, now it is time for getting
+				// the actual area:
+				weights.rg = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.y ) );
+			}
+
+			if ( e.r > 0.0 ) { // Edge at west
+				vec2 d;
+
+				// Find the distance to the top:
+				vec2 coords;
+
+				coords.y = SMAASearchYUp( edgesTex, searchTex, offset[ 1 ].xy, offset[ 2 ].z );
+				coords.x = offset[ 0 ].x; // offset[1].x = texcoord.x - 0.25 * resolution.x;
+				d.x = coords.y;
+
+				// Fetch the top crossing edges:
+				float e1 = texture2D( edgesTex, coords, 0.0 ).g;
+
+				// Find the distance to the bottom:
+				coords.y = SMAASearchYDown( edgesTex, searchTex, offset[ 1 ].zw, offset[ 2 ].w );
+				d.y = coords.y;
+
+				// We want the distances to be in pixel units:
+				d = d / resolution.y - pixcoord.y;
+
+				// SMAAArea below needs a sqrt, as the areas texture is compressed
+				// quadratically:
+				vec2 sqrt_d = sqrt( abs( d ) );
+
+				// Fetch the bottom crossing edges:
+				coords.y -= 1.0 * resolution.y; // WebGL port note: Added
+				float e2 = SMAASampleLevelZeroOffset( edgesTex, coords, ivec2( 0, 1 ) ).g;
+
+				// Get the area for this direction:
+				weights.ba = SMAAArea( areaTex, sqrt_d, e1, e2, float( subsampleIndices.x ) );
+			}
+
+			return weights;
+		}
+
+		void main() {
+
+			gl_FragColor = SMAABlendingWeightCalculationPS( vUv, vPixcoord, vOffset, tDiffuse, tArea, tSearch, ivec4( 0.0 ) );
+
+		}`
+    )
+  };
+  var SMAABlendShader = {
+    name: "SMAABlendShader",
+    uniforms: {
+      "tDiffuse": { value: null },
+      "tColor": { value: null },
+      "resolution": { value: new Vector2(1 / 1024, 1 / 512) }
+    },
+    vertexShader: (
+      /* glsl */
+      `
+
+		uniform vec2 resolution;
+
+		varying vec2 vUv;
+		varying vec4 vOffset[ 2 ];
+
+		void SMAANeighborhoodBlendingVS( vec2 texcoord ) {
+			vOffset[ 0 ] = texcoord.xyxy + resolution.xyxy * vec4( -1.0, 0.0, 0.0, 1.0 ); // WebGL port note: Changed sign in W component
+			vOffset[ 1 ] = texcoord.xyxy + resolution.xyxy * vec4( 1.0, 0.0, 0.0, -1.0 ); // WebGL port note: Changed sign in W component
+		}
+
+		void main() {
+
+			vUv = uv;
+
+			SMAANeighborhoodBlendingVS( vUv );
+
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+		}`
+    ),
+    fragmentShader: (
+      /* glsl */
+      `
+
+		uniform sampler2D tDiffuse;
+		uniform sampler2D tColor;
+		uniform vec2 resolution;
+
+		varying vec2 vUv;
+		varying vec4 vOffset[ 2 ];
+
+		vec4 SMAANeighborhoodBlendingPS( vec2 texcoord, vec4 offset[ 2 ], sampler2D colorTex, sampler2D blendTex ) {
+			// Fetch the blending weights for current pixel:
+			vec4 a;
+			a.xz = texture2D( blendTex, texcoord ).xz;
+			a.y = texture2D( blendTex, offset[ 1 ].zw ).g;
+			a.w = texture2D( blendTex, offset[ 1 ].xy ).a;
+
+			// Is there any blending weight with a value greater than 0.0?
+			if ( dot(a, vec4( 1.0, 1.0, 1.0, 1.0 )) < 1e-5 ) {
+				return texture2D( colorTex, texcoord, 0.0 );
+			} else {
+				// Up to 4 lines can be crossing a pixel (one through each edge). We
+				// favor blending by choosing the line with the maximum weight for each
+				// direction:
+				vec2 offset;
+				offset.x = a.a > a.b ? a.a : -a.b; // left vs. right
+				offset.y = a.g > a.r ? -a.g : a.r; // top vs. bottom // WebGL port note: Changed signs
+
+				// Then we go in the direction that has the maximum weight:
+				if ( abs( offset.x ) > abs( offset.y )) { // horizontal vs. vertical
+					offset.y = 0.0;
+				} else {
+					offset.x = 0.0;
+				}
+
+				// Fetch the opposite color and lerp by hand:
+				vec4 C = texture2D( colorTex, texcoord, 0.0 );
+				texcoord += sign( offset ) * resolution;
+				vec4 Cop = texture2D( colorTex, texcoord, 0.0 );
+				float s = abs( offset.x ) > abs( offset.y ) ? abs( offset.x ) : abs( offset.y );
+
+				// WebGL port note: Added gamma correction
+				C.xyz = pow(C.xyz, vec3(2.2));
+				Cop.xyz = pow(Cop.xyz, vec3(2.2));
+				vec4 mixed = mix(C, Cop, s);
+				mixed.xyz = pow(mixed.xyz, vec3(1.0 / 2.2));
+
+				return mixed;
+			}
+		}
+
+		void main() {
+
+			gl_FragColor = SMAANeighborhoodBlendingPS( vUv, vOffset, tColor, tDiffuse );
+
+		}`
+    )
+  };
+
+  // node_modules/three/examples/jsm/postprocessing/SMAAPass.js
+  var SMAAPass = class extends Pass {
+    constructor(width, height) {
+      super();
+      this.edgesRT = new WebGLRenderTarget(width, height, {
+        depthBuffer: false,
+        type: HalfFloatType
+      });
+      this.edgesRT.texture.name = "SMAAPass.edges";
+      this.weightsRT = new WebGLRenderTarget(width, height, {
+        depthBuffer: false,
+        type: HalfFloatType
+      });
+      this.weightsRT.texture.name = "SMAAPass.weights";
+      const scope = this;
+      const areaTextureImage = new Image();
+      areaTextureImage.src = this.getAreaTexture();
+      areaTextureImage.onload = function() {
+        scope.areaTexture.needsUpdate = true;
+      };
+      this.areaTexture = new Texture();
+      this.areaTexture.name = "SMAAPass.area";
+      this.areaTexture.image = areaTextureImage;
+      this.areaTexture.minFilter = LinearFilter;
+      this.areaTexture.generateMipmaps = false;
+      this.areaTexture.flipY = false;
+      const searchTextureImage = new Image();
+      searchTextureImage.src = this.getSearchTexture();
+      searchTextureImage.onload = function() {
+        scope.searchTexture.needsUpdate = true;
+      };
+      this.searchTexture = new Texture();
+      this.searchTexture.name = "SMAAPass.search";
+      this.searchTexture.image = searchTextureImage;
+      this.searchTexture.magFilter = NearestFilter;
+      this.searchTexture.minFilter = NearestFilter;
+      this.searchTexture.generateMipmaps = false;
+      this.searchTexture.flipY = false;
+      this.uniformsEdges = UniformsUtils.clone(SMAAEdgesShader.uniforms);
+      this.uniformsEdges["resolution"].value.set(1 / width, 1 / height);
+      this.materialEdges = new ShaderMaterial({
+        defines: Object.assign({}, SMAAEdgesShader.defines),
+        uniforms: this.uniformsEdges,
+        vertexShader: SMAAEdgesShader.vertexShader,
+        fragmentShader: SMAAEdgesShader.fragmentShader
+      });
+      this.uniformsWeights = UniformsUtils.clone(SMAAWeightsShader.uniforms);
+      this.uniformsWeights["resolution"].value.set(1 / width, 1 / height);
+      this.uniformsWeights["tDiffuse"].value = this.edgesRT.texture;
+      this.uniformsWeights["tArea"].value = this.areaTexture;
+      this.uniformsWeights["tSearch"].value = this.searchTexture;
+      this.materialWeights = new ShaderMaterial({
+        defines: Object.assign({}, SMAAWeightsShader.defines),
+        uniforms: this.uniformsWeights,
+        vertexShader: SMAAWeightsShader.vertexShader,
+        fragmentShader: SMAAWeightsShader.fragmentShader
+      });
+      this.uniformsBlend = UniformsUtils.clone(SMAABlendShader.uniforms);
+      this.uniformsBlend["resolution"].value.set(1 / width, 1 / height);
+      this.uniformsBlend["tDiffuse"].value = this.weightsRT.texture;
+      this.materialBlend = new ShaderMaterial({
+        uniforms: this.uniformsBlend,
+        vertexShader: SMAABlendShader.vertexShader,
+        fragmentShader: SMAABlendShader.fragmentShader
+      });
+      this.fsQuad = new FullScreenQuad(null);
+    }
+    render(renderer2, writeBuffer, readBuffer) {
+      this.uniformsEdges["tDiffuse"].value = readBuffer.texture;
+      this.fsQuad.material = this.materialEdges;
+      renderer2.setRenderTarget(this.edgesRT);
+      if (this.clear) renderer2.clear();
+      this.fsQuad.render(renderer2);
+      this.fsQuad.material = this.materialWeights;
+      renderer2.setRenderTarget(this.weightsRT);
+      if (this.clear) renderer2.clear();
+      this.fsQuad.render(renderer2);
+      this.uniformsBlend["tColor"].value = readBuffer.texture;
+      this.fsQuad.material = this.materialBlend;
+      if (this.renderToScreen) {
+        renderer2.setRenderTarget(null);
+        this.fsQuad.render(renderer2);
+      } else {
+        renderer2.setRenderTarget(writeBuffer);
+        if (this.clear) renderer2.clear();
+        this.fsQuad.render(renderer2);
+      }
+    }
+    setSize(width, height) {
+      this.edgesRT.setSize(width, height);
+      this.weightsRT.setSize(width, height);
+      this.materialEdges.uniforms["resolution"].value.set(1 / width, 1 / height);
+      this.materialWeights.uniforms["resolution"].value.set(1 / width, 1 / height);
+      this.materialBlend.uniforms["resolution"].value.set(1 / width, 1 / height);
+    }
+    getAreaTexture() {
+      return "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKAAAAIwCAIAAACOVPcQAACBeklEQVR42u39W4xlWXrnh/3WWvuciIzMrKxrV8/0rWbY0+SQFKcb4owIkSIFCjY9AC1BT/LYBozRi+EX+cV+8IMsYAaCwRcBwjzMiw2jAWtgwC8WR5Q8mDFHZLNHTarZGrLJJllt1W2qKrsumZWZcTvn7L3W54e1vrXX3vuciLPPORFR1XE2EomorB0nVuz//r71re/y/1eMvb4Cb3N11xV/PP/2v4UBAwJG/7H8urx6/25/Gf8O5hypMQ0EEEQwAqLfoN/Z+97f/SW+/NvcgQk4sGBJK6H7N4PFVL+K+e0N11yNfkKvwUdwdlUAXPHHL38oa15f/i/46Ih6SuMSPmLAYAwyRKn7dfMGH97jaMFBYCJUgotIC2YAdu+LyW9vvubxAP8kAL8H/koAuOKP3+q6+xGnd5kdYCeECnGIJViwGJMAkQKfDvB3WZxjLKGh8VSCCzhwEWBpMc5/kBbjawT4HnwJfhr+pPBIu7uu+OOTo9vsmtQcniMBGkKFd4jDWMSCRUpLjJYNJkM+IRzQ+PQvIeAMTrBS2LEiaiR9b/5PuT6Ap/AcfAFO4Y3dA3DFH7/VS+M8k4baEAQfMI4QfbVDDGIRg7GKaIY52qAjTAgTvGBAPGIIghOCYAUrGFNgzA7Q3QhgCwfwAnwe5vDejgG44o/fbm1C5ZlYQvQDARPAIQGxCWBM+wWl37ZQESb4gImexGMDouhGLx1Cst0Saa4b4AqO4Hk4gxo+3DHAV/nx27p3JziPM2pVgoiia5MdEzCGULprIN7gEEeQ5IQxEBBBQnxhsDb5auGmAAYcHMA9eAAz8PBol8/xij9+C4Djlim4gJjWcwZBhCBgMIIYxGAVIkH3ZtcBuLdtRFMWsPGoY9rN+HoBji9VBYdwD2ZQg4cnO7OSq/z4rU5KKdwVbFAjNojCQzTlCLPFSxtamwh2jMUcEgg2Wm/6XgErIBhBckQtGN3CzbVacERgCnfgLswhnvqf7QyAq/z4rRZm1YglYE3affGITaZsdIe2FmMIpnOCap25I6jt2kCwCW0D1uAD9sZctNGXcQIHCkINDQgc78aCr+zjtw3BU/ijdpw3zhCwcaONwBvdeS2YZKkJNJsMPf2JKEvC28RXxxI0ASJyzQCjCEQrO4Q7sFArEzjZhaFc4cdv+/JFdKULM4px0DfUBI2hIsy06BqLhGTQEVdbfAIZXYMPesq6VoCHICzUyjwInO4Y411//LYLs6TDa9wvg2CC2rElgAnpTBziThxaL22MYhzfkghz6GAs2VHbbdM91VZu1MEEpupMMwKyVTb5ij9+u4VJG/5EgEMMmFF01cFai3isRbKbzb+YaU/MQbAm2XSMoUPAmvZzbuKYRIFApbtlrfFuUGd6vq2hXNnH78ZLh/iFhsQG3T4D1ib7k5CC6vY0DCbtrohgLEIClXiGtl10zc0CnEGIhhatLBva7NP58Tvw0qE8yWhARLQ8h4+AhQSP+I4F5xoU+VilGRJs6wnS7ruti/4KvAY/CfdgqjsMy4pf8fodQO8/gnuX3f/3xi3om1/h7THr+co3x93PP9+FBUfbNUjcjEmhcrkT+8K7ml7V10Jo05mpIEFy1NmCJWx9SIKKt+EjAL4Ez8EBVOB6havuT/rByPvHXK+9zUcfcbb254+9fydJknYnRr1oGfdaiAgpxu1Rx/Rek8KISftx3L+DfsLWAANn8Hvw0/AFeAGO9DFV3c6D+CcWbL8Dj9e7f+T1k8AZv/d7+PXWM/Z+VvdCrIvuAKO09RpEEQJM0Ci6+B4xhTWr4cZNOvhktabw0ta0rSJmqz3Yw5/AKXwenod7cAhTmBSPKf6JBdvH8IP17h95pXqw50/+BFnj88fev4NchyaK47OPhhtI8RFSvAfDSNh0Ck0p2gLxGkib5NJj/JWCr90EWQJvwBzO4AHcgztwAFN1evHPUVGwfXON+0debT1YeGON9Yy9/63X+OguiwmhIhQhD7l4sMqlG3D86Suc3qWZ4rWjI1X7u0Ytw6x3rIMeIOPDprfe2XzNgyj6PahhBjO4C3e6puDgXrdg+/5l948vF3bqwZetZ+z9Rx9zdIY5pInPK4Nk0t+l52xdK2B45Qd87nM8fsD5EfUhIcJcERw4RdqqH7Yde5V7m1vhNmtedkz6EDzUMF/2jJYWbC+4fzzA/Y+/8PPH3j9dcBAPIRP8JLXd5BpAu03aziOL3VVHZzz3CXWDPWd+SH2AnxIqQoTZpo9Ckc6HIrFbAbzNmlcg8Ag8NFDDAhbJvTBZXbC94P7t68EXfv6o+21gUtPETU7bbkLxvNKRFG2+KXzvtObonPP4rBvsgmaKj404DlshFole1Glfh02fE7bYR7dZ82oTewIBGn1Md6CG6YUF26X376oevOLzx95vhUmgblI6LBZwTCDY7vMq0op5WVXgsObOXJ+1x3qaBl9j1FeLxbhU9w1F+Wiba6s1X/TBz1LnUfuYDi4r2C69f1f14BWfP+p+W2GFKuC9phcELMYRRLur9DEZTUdEH+iEqWdaM7X4WOoPGI+ZYD2+wcQ+y+ioHUZ9dTDbArzxmi/bJI9BND0Ynd6lBdve/butBw8+f/T9D3ABa3AG8W3VPX4hBin+bj8dMMmSpp5pg7fJ6xrBFE2WQQEWnV8Qg3FbAWzYfM1rREEnmvkN2o1+acG2d/9u68GDzx91v3mAjb1zkpqT21OipPKO0b9TO5W0nTdOmAQm0TObts3aBKgwARtoPDiCT0gHgwnbArzxmtcLc08HgF1asN0C4Ms/fvD5I+7PhfqyXE/b7RbbrGyRQRT9ARZcwAUmgdoz0ehJ9Fn7QAhUjhDAQSw0bV3T3WbNa59jzmiP6GsWbGXDX2ytjy8+f9T97fiBPq9YeLdBmyuizZHaqXITnXiMUEEVcJ7K4j3BFPurtB4bixW8wTpweL8DC95szWMOqucFYGsWbGU7p3TxxxefP+r+oTVktxY0v5hbq3KiOKYnY8ddJVSBxuMMVffNbxwIOERShst73HZ78DZrHpmJmH3K6sGz0fe3UUj0eyRrSCGTTc+rjVNoGzNSv05srAxUBh8IhqChiQgVNIIBH3AVPnrsnXQZbLTm8ammv8eVXn/vWpaTem5IXRlt+U/LA21zhSb9cye6jcOfCnOwhIAYXAMVTUNV0QhVha9xjgA27ODJbLbmitt3tRN80lqG6N/khgot4ZVlOyO4WNg3OIMzhIZQpUEHieg2im6F91hB3I2tubql6BYNN9Hj5S7G0G2tahslBWKDnOiIvuAEDzakDQKDNFQT6gbn8E2y4BBubM230YIpBnDbMa+y3dx0n1S0BtuG62lCCXwcY0F72T1VRR3t2ONcsmDjbmzNt9RFs2LO2hQNyb022JisaI8rAWuw4HI3FuAIhZdOGIcdjLJvvObqlpqvWTJnnQbyi/1M9O8UxWhBs//H42I0q1Yb/XPGONzcmm+ri172mHKvZBpHkJaNJz6v9jxqiklDj3U4CA2ugpAaYMWqNXsdXbmJNd9egCnJEsphXNM+MnK3m0FCJ5S1kmJpa3DgPVbnQnPGWIDspW9ozbcO4K/9LkfaQO2KHuqlfFXSbdNzcEcwoqNEFE9zcIXu9/6n/ym/BC/C3aJLzEKPuYVlbFnfhZ8kcWxV3dbv4bKl28566wD+8C53aw49lTABp9PWbsB+knfc/Li3eVizf5vv/xmvnPKg5ihwKEwlrcHqucuVcVOxEv8aH37E3ZqpZypUulrHEtIWKUr+txHg+ojZDGlwnqmkGlzcVi1dLiNSJiHjfbRNOPwKpx9TVdTn3K05DBx4psIk4Ei8aCkJahRgffk4YnEXe07T4H2RR1u27E6wfQsBDofUgjFUFnwC2AiVtA+05J2zpiDK2Oa0c5fmAecN1iJzmpqFZxqYBCYhFTCsUNEmUnIcZ6aEA5rQVhEywG6w7HSW02XfOoBlQmjwulOFQAg66SvJblrTEX1YtJ3uG15T/BH1OfOQeuR8g/c0gdpT5fx2SKbs9EfHTKdM8A1GaJRHLVIwhcGyydZsbifAFVKl5EMKNU2Hryo+06BeTgqnxzYjThVySDikbtJPieco75lYfKAJOMEZBTjoITuWHXXZVhcUDIS2hpiXHV9Ku4u44bN5OYLDOkJo8w+xJSMbhBRHEdEs9JZUCkQrPMAvaHyLkxgkEHxiNkx/x2YB0mGsQ8EUWj/stW5YLhtS5SMu+/YBbNPDCkGTUybN8krRLBGPlZkVOA0j+a1+rkyQKWGaPHPLZOkJhioQYnVZ2hS3zVxMtgC46KuRwbJNd9nV2PHgb36F194ecf/Yeu2vAFe5nm/bRBFrnY4BauE8ERmZRFUn0k8hbftiVYSKMEme2dJCJSCGYAlNqh87bXOPdUkGy24P6d1ll21MBqqx48Fvv8ZHH8HZFY7j/uAq1xMJUFqCSUlJPmNbIiNsmwuMs/q9CMtsZsFO6SprzCS1Z7QL8xCQClEelpjTduDMsmWD8S1PT152BtvmIGvUeDA/yRn83u/x0/4qxoPHjx+PXY9pqX9bgMvh/Nz9kpP4pOe1/fYf3axUiMdHLlPpZCNjgtNFAhcHEDxTumNONhHrBduW+vOyY++70WWnPXj98eA4kOt/mj/5E05l9+O4o8ePx67HFqyC+qSSnyselqjZGaVK2TadbFLPWAQ4NBhHqDCCV7OTpo34AlSSylPtIdd2AJZlyzYQrDJ5lcWGNceD80CunPLGGzsfD+7wRb95NevJI5docQ3tgCyr5bGnyaPRlmwNsFELViOOx9loebGNq2moDOKpHLVP5al2cymWHbkfzGXL7kfRl44H9wZy33tvt+PB/Xnf93e+nh5ZlU18wCiRUa9m7kib9LYuOk+hudQNbxwm0AQqbfloimaB2lM5fChex+ylMwuTbfmXQtmWlenZljbdXTLuOxjI/fDDHY4Hjx8/Hrse0zXfPFxbUN1kKqSCCSk50m0Ajtx3ub9XHBKHXESb8iO6E+qGytF4nO0OG3SXzbJlhxBnKtKyl0NwybjvYCD30aMdjgePHz8eu56SVTBbgxJMliQ3Oauwg0QHxXE2Ez/EIReLdQj42Gzb4CLS0YJD9xUx7bsi0vJi5mUbW1QzL0h0PFk17rtiIPfJk52MB48fPx67npJJwyrBa2RCCQRTbGZSPCxTPOiND4G2pYyOQ4h4jINIJh5wFU1NFZt+IsZ59LSnDqBjZ2awbOku+yInunLcd8VA7rNnOxkPHj9+PGY9B0MWJJNozOJmlglvDMXDEozdhQWbgs/U6oBanGzLrdSNNnZFjOkmbi5bNt1lX7JLLhn3vXAg9/h4y/Hg8ePHI9dzQMEkWCgdRfYykYKnkP7D4rIujsujaKPBsB54vE2TS00ccvFY/Tth7JXeq1hz+qgVy04sAJawTsvOknHfCwdyT062HA8eP348Zj0vdoXF4pilKa2BROed+9fyw9rWRXeTFXESMOanvDZfJuJaSXouQdMdDJZtekZcLLvEeK04d8m474UDuaenW44Hjx8/Xns9YYqZpszGWB3AN/4VHw+k7WSFtJ3Qicuqb/NlVmgXWsxh570xg2UwxUw3WfO6B5nOuO8aA7lnZxuPB48fPx6znm1i4bsfcbaptF3zNT78eFPtwi1OaCNOqp1x3zUGcs/PN++AGD1+fMXrSVm2baTtPhPahbPhA71wIHd2bXzRa69nG+3CraTtPivahV/55tXWg8fyRY/9AdsY8VbSdp8V7cKrrgdfM//z6ILQFtJ2nxHtwmuoB4/kf74+gLeRtvvMaBdeSz34+vifx0YG20jbfTa0C6+tHrwe//NmOG0L8EbSdp8R7cLrrQe/996O+ai3ujQOskpTNULa7jOjXXj99eCd8lHvoFiwsbTdZ0a78PrrwTvlo966pLuRtB2fFe3Cm6oHP9kNH/W2FryxtN1nTLvwRurBO+Kj3pWXHidtx2dFu/Bm68Fb81HvykuPlrb7LGkX3mw9eGs+6h1Y8MbSdjegXcguQLjmevDpTQLMxtJ2N6NdyBZu9AbrwVvwUW+LbteULUpCdqm0HTelXbhNPe8G68Gb8lFvVfYfSNuxvrTdTWoXbozAzdaDZzfkorOj1oxVxlIMlpSIlpLrt8D4hrQL17z+c3h6hU/wv4Q/utps4+bm+6P/hIcf0JwQ5oQGPBL0eKPTYEXTW+eL/2DKn73J9BTXYANG57hz1cEMviVf/4tf5b/6C5pTQkMIWoAq7hTpOJjtAM4pxKu5vg5vXeUrtI09/Mo/5H+4z+Mp5xULh7cEm2QbRP2tFIKR7WM3fPf/jZ3SWCqLM2l4NxID5zB72HQXv3jj/8mLR5xXNA5v8EbFQEz7PpRfl1+MB/hlAN65qgDn3wTgH13hK7T59bmP+NIx1SHHU84nLOITt3iVz8mNO+lPrjGAnBFqmioNn1mTyk1ta47R6d4MrX7tjrnjYUpdUbv2rVr6YpVfsGG58AG8Ah9eyUN8CX4WfgV+G8LVWPDGb+Zd4cU584CtqSbMKxauxTg+dyn/LkVgA+IR8KHtejeFKRtTmLLpxN6mYVLjYxwXf5x2VofiZcp/lwKk4wGOpYDnoIZPdg/AAbwMfx0+ge9dgZvYjuqKe4HnGnykYo5TvJbG0Vj12JagRhwKa44H95ShkZa5RyLGGdfYvG7aw1TsF6iapPAS29mNS3NmsTQZCmgTzFwgL3upCTgtBTRwvGMAKrgLn4evwin8+afJRcff+8izUGUM63GOOuAs3tJkw7J4kyoNreqrpO6cYLQeFUd7TTpr5YOTLc9RUUogUOVJQ1GYJaFLAW0oTmKyYS46ZooP4S4EON3xQ5zC8/CX4CnM4c1PE8ApexpoYuzqlP3d4S3OJP8ZDK7cKWNaTlqmgDiiHwl1YsE41w1zT4iRTm3DBqxvOUsbMKKDa/EHxagtnta072ejc3DOIh5ojvh8l3tk1JF/AV6FU6jh3U8HwEazLgdCLYSQ+MYiAI2ltomkzttUb0gGHdSUUgsIYjTzLG3mObX4FBRaYtpDVNZrih9TgTeYOBxsEnN1gOCTM8Bsw/ieMc75w9kuAT6A+/AiHGvN/+Gn4KRkiuzpNNDYhDGFndWRpE6SVfm8U5bxnSgVV2jrg6JCKmneqey8VMFgq2+AM/i4L4RUbfSi27lNXZ7R7W9RTcq/q9fk4Xw3AMQd4I5ifAZz8FcVtm9SAom/dyN4lczJQW/kC42ZrHgcCoIf1oVMKkVItmMBi9cOeNHGLqOZk+QqQmrbc5YmYgxELUUN35z2iohstgfLIFmcMV7s4CFmI74L9+EFmGsi+tGnAOD4Yk9gIpo01Y4cA43BWGygMdr4YZekG3OBIUXXNukvJS8tqa06e+lSDCtnqqMFu6hWHXCF+WaYt64m9QBmNxi7Ioy7D+fa1yHw+FMAcPt7SysFLtoG4PXAk7JOA3aAxBRqUiAdU9Yp5lK3HLSRFtOim0sa8euEt08xvKjYjzeJ2GU7YawexrnKI9tmobInjFXCewpwriY9+RR4aaezFhMhGCppKwom0ChrgFlKzyPKkGlTW1YQrE9HJqu8hKGgMc6hVi5QRq0PZxNfrYNgE64utmRv6KKHRpxf6VDUaOvNP5jCEx5q185My/7RKz69UQu2im5k4/eownpxZxNLwiZ1AZTO2ZjWjkU9uaB2HFn6Q3u0JcsSx/qV9hTEApRzeBLDJQXxYmTnq7bdLa3+uqFrxLJ5w1TehnNHx5ECvCh2g2c3hHH5YsfdaSKddztfjQ6imKFGSyFwlLzxEGPp6r5IevVjk1AMx3wMqi1NxDVjLBiPs9tbsCkIY5we5/ML22zrCScFxnNtzsr9Wcc3CnD+pYO+4VXXiDE0oc/vQQ/fDK3oPESJMYXNmJa/DuloJZkcTpcYE8lIH8Dz8DJMiynNC86Mb2lNaaqP/+L7f2fcE/yP7/Lde8xfgSOdMxvOixZf/9p3+M4hT1+F+zApxg9XfUvYjc8qX2lfOOpK2gNRtB4flpFu9FTKCp2XJRgXnX6olp1zyYjTKJSkGmLE2NjUr1bxFM4AeAAHBUFIeSLqXR+NvH/M9fOnfHzOD2vCSyQJKzfgsCh+yi/Mmc35F2fUrw7miW33W9hBD1vpuUojFphIyvg7aTeoymDkIkeW3XLHmguMzbIAJejN6B5MDrhipE2y6SoFRO/AK/AcHHZHNIfiWrEe/C6cr3f/yOvrQKB+zMM55/GQdLDsR+ifr5Fiuu+/y+M78LzOE5dsNuXC3PYvYWd8NXvphLSkJIasrlD2/HOqQ+RjcRdjKTGWYhhVUm4yxlyiGPuMsZR7sMCHUBeTuNWA7if+ifXgc/hovftHXs/DV+Fvwe+f8shzMiMcweFgBly3//vwJfg5AN4450fn1Hd1Rm1aBLu22Dy3y3H2+OqMemkbGZ4jozcDjJf6596xOLpC0eMTHbKnxLxH27uZ/bMTGs2jOaMOY4m87CfQwF0dw53oa1k80JRuz/XgS+8fX3N9Af4qPIMfzKgCp4H5TDGe9GGeFPzSsZz80SlPTxXjgwJmC45njzgt2vbQ4b4OAdUK4/vWhO8d8v6EE8fMUsfakXbPpFJeLs2ubM/qdm/la3WP91uWhxXHjoWhyRUq2iJ/+5mA73zwIIo+LoZ/SgvIRjAd1IMvvn98PfgOvAJfhhm8scAKVWDuaRaK8aQ9f7vuPDH6Bj47ZXau7rqYJ66mTDwEDU6lLbCjCK0qTXyl5mnDoeNRxanj3FJbaksTk0faXxHxLrssgPkWB9LnA/MFleXcJozzjwsUvUG0X/QCve51qkMDXp9mtcyOy3rwBfdvVJK7D6/ACSzg3RoruIq5UDeESfEmVclDxnniU82vxMLtceD0hGZWzBNPMM/jSPne2OVatiTKUpY5vY7gc0LdUAWeWM5tH+O2I66AOWw9xT2BuyRVLGdoDHUsVRXOo/c+ZdRXvFfnxWyIV4upFLCl9eAL7h8Zv0QH8Ry8pA2cHzQpGesctVA37ZtklBTgHjyvdSeKY/RZw/kJMk0Y25cSNRWSigQtlULPTw+kzuJPeYEkXjQRpoGZobYsLF79pyd1dMRHInbgFTZqNLhDqiIsTNpoex2WLcy0/X6rHcdMMQvFSd5dWA++4P7xv89deACnmr36uGlL69bRCL6BSZsS6c0TU2TKK5gtWCzgAOOwQcurqk9j8whvziZSMLcq5hbuwBEsYjopUBkqw1yYBGpLA97SRElEmx5MCInBY5vgLk94iKqSWmhIGmkJ4Bi9m4L645J68LyY4wsFYBfUg5feP/6gWWm58IEmKQM89hq7KsZNaKtP5TxxrUZZVkNmMJtjbKrGxLNEbHPJxhqy7lAmbC32ZqeF6lTaknRWcYaFpfLUBh/rwaQycCCJmW15Kstv6jRHyJFry2C1ahkkIW0LO75s61+owxK1y3XqweX9m5YLM2DPFeOjn/iiqCKJ+yKXF8t5Yl/kNsqaSCryxPq5xWTFIaP8KSW0RYxqupaUf0RcTNSSdJZGcKYdYA6kdtrtmyBckfKXwqk0pHpUHlwWaffjNRBYFPUDWa8e3Lt/o0R0CdisKDM89cX0pvRHEfM8ca4t0s2Xx4kgo91MPQJ/0c9MQYq0co8MBh7bz1fio0UUHLR4aAIOvOmoYO6kwlEVODSSTliWtOtH6sPkrtctF9ZtJ9GIerBskvhdVS5cFNv9s1BU0AbdUgdK4FG+dRnjFmDTzniRMdZO1QhzMK355vigbdkpz9P6qjUGE5J2qAcXmwJ20cZUiAD0z+pGMx6xkzJkmEf40Hr4qZfVg2XzF9YOyoV5BjzVkUJngKf8lgNYwKECEHrCNDrWZzMlflS3yBhr/InyoUgBc/lKT4pxVrrC6g1YwcceK3BmNxZcAtz3j5EIpqguh9H6wc011YN75cKDLpFDxuwkrPQmUwW4KTbj9mZTwBwLq4aQMUZbHm1rylJ46dzR0dua2n3RYCWZsiHROeywyJGR7mXKlpryyCiouY56sFkBWEnkEB/raeh/Sw4162KeuAxMQpEkzy5alMY5wamMsWKKrtW2WpEWNnReZWONKWjrdsKZarpFjqCslq773PLmEhM448Pc3+FKr1+94vv/rfw4tEcu+lKTBe4kZSdijBrykwv9vbCMPcLQTygBjzVckSLPRVGslqdunwJ4oegtFOYb4SwxNgWLCmD7T9kVjTv5YDgpo0XBmN34Z/rEHp0sgyz7lngsrm4lvMm2Mr1zNOJYJ5cuxuQxwMGJq/TP5emlb8fsQBZviK4t8hFL+zbhtlpwaRSxQRWfeETjuauPsdGxsBVdO7nmP4xvzSoT29pRl7kGqz+k26B3Oy0YNV+SXbbQas1ctC/GarskRdFpKczVAF1ZXnLcpaMuzVe6lZ2g/1ndcvOVgRG3sdUAY1bKD6achijMPdMxV4muKVorSpiDHituH7rSTs7n/4y5DhRXo4FVBN4vO/zbAcxhENzGbHCzU/98Mcx5e7a31kWjw9FCe/zNeYyQjZsWb1uc7U33pN4Mji6hCLhivqfa9Ss6xLg031AgfesA/l99m9fgvnaF9JoE6bYKmkGNK3aPbHB96w3+DnxFm4hs0drLsk7U8kf/N/CvwQNtllna0rjq61sH8L80HAuvwH1tvBy2ChqWSCaYTaGN19sTvlfzFD6n+iKTbvtayfrfe9ueWh6GJFoxLdr7V72a5ZpvHcCPDzma0wTO4EgbLyedxstO81n57LYBOBzyfsOhUKsW1J1BB5vr/tz8RyqOFylQP9Tvst2JALsC5lsH8PyQ40DV4ANzYa4dedNiKNR1s+x2wwbR7q4/4cTxqEk4LWDebfisuo36JXLiWFjOtLrlNWh3K1rRS4xvHcDNlFnNmWBBAl5SWaL3oPOfnvbr5pdjVnEaeBJSYjuLEkyLLsWhKccadmOphZkOPgVdalj2QpSmfOsADhMWE2ZBu4+EEJI4wKTAuCoC4xwQbWXBltpxbjkXJtKxxabo9e7tyhlgb6gNlSbUpMh+l/FaqzVwewGu8BW1Zx7pTpQDJUjb8tsUTW6+GDXbMn3mLbXlXJiGdggxFAoUrtPS3wE4Nk02UZG2OOzlk7fRs7i95QCLo3E0jtrjnM7SR3uS1p4qtS2nJ5OwtQVHgOvArLBFijZUV9QtSl8dAY5d0E0hM0w3HS2DpIeB6m/A1+HfhJcGUq4sOxH+x3f5+VO+Ds9rYNI7zPXOYWPrtf8bYMx6fuOAX5jzNR0PdsuON+X1f7EERxMJJoU6GkTEWBvVolVlb5lh3tKCg6Wx1IbaMDdJ+9sUCc5KC46hKGCk3IVOS4TCqdBNfUs7Kd4iXf2RjnT/LLysJy3XDcHLh/vde3x8DoGvwgsa67vBk91G5Pe/HbOe7xwym0NXbtiuuDkGO2IJDh9oQvJ4cY4vdoqLDuoH9Zl2F/ofsekn8lkuhIlhQcffUtSjytFyp++p6NiE7Rqx/lodgKVoceEp/CP4FfjrquZaTtj2AvH5K/ywpn7M34K/SsoYDAdIN448I1/0/wveW289T1/lX5xBzc8N5IaHr0XMOQdHsIkDuJFifj20pBm5jzwUv9e2FhwRsvhAbalCIuIw3bhJihY3p6nTFFIZgiSYjfTf3aXuOjmeGn4bPoGvwl+CFzTRczBIuHBEeImHc37/lGfwZR0cXzVDOvaKfNHvwe+suZ771K/y/XcBlsoN996JpBhoE2toYxOznNEOS5TJc6Id5GEXLjrWo+LEWGNpPDU4WAwsIRROu+1vM+0oW37z/MBN9kqHnSArwPfgFJ7Cq/Ai3Ie7g7ncmI09v8sjzw9mzOAEXoIHxURueaAce5V80f/DOuuZwHM8vsMb5wBzOFWM7wymTXPAEvm4vcFpZ2ut0VZRjkiP2MlmLd6DIpbGSiHOjdnUHN90hRYmhTnmvhzp1iKDNj+b7t5hi79lWGwQ+HN9RsfFMy0FXbEwhfuczKgCbyxYwBmcFhhvo/7a44v+i3XWcwDP86PzpGQYdWh7csP5dBvZ1jNzdxC8pBGuxqSW5vw40nBpj5JhMwvOzN0RWqERHMr4Lv1kWX84xLR830G3j6yqZ1a8UstTlW+qJPOZ+sZ7xZPKTJLhiNOAFd6tk+jrTH31ncLOxid8+nzRb128HhUcru/y0Wn6iT254YPC6FtVSIMoW2sk727AhvTtrWKZTvgsmckfXYZWeNRXx/3YQ2OUxLDrbHtN11IwrgXT6c8dATDwLniYwxzO4RzuQqTKSC5gAofMZ1QBK3zQ4JWobFbcvJm87FK+6JXrKahLn54m3p+McXzzYtP8VF/QpJuh1OwieElEoI1pRxPS09FBrkq2tWCU59+HdhNtTIqKm8EBrw2RTOEDpG3IKo2Y7mFdLm3ZeVjYwVw11o/oznceMve4CgMfNym/utA/d/ILMR7gpXzRy9eDsgLcgbs8O2Va1L0zzIdwGGemTBuwROHeoMShkUc7P+ISY3KH5ZZeWqO8mFTxQYeXTNuzvvK5FGPdQfuu00DwYFY9dyhctEt+OJDdnucfpmyhzUJzfsJjr29l8S0bXBfwRS9ZT26tmMIdZucch5ZboMz3Nio3nIOsYHCGoDT4kUA9MiXEp9Xsui1S8th/kbWIrMBxDGLodWUQIWcvnXy+9M23xPiSMOiRPqM+YMXkUN3gXFrZJwXGzUaMpJfyRS9ZT0lPe8TpScuRlbMHeUmlaKDoNuy62iWNTWNFYjoxFzuJs8oR+RhRx7O4SVNSXpa0ZJQ0K1LAHDQ+D9IepkMXpcsq5EVCvClBUIzDhDoyKwDw1Lc59GbTeORivugw1IcuaEOaGWdNm+Ps5fQ7/tm0DjMegq3yM3vb5j12qUId5UZD2oxDSEWOZMSqFl/W+5oynWDa/aI04tJRQ2eTXusg86SQVu/nwSYwpW6wLjlqIzwLuxGIvoAvul0PS+ZNz0/akp/pniO/8JDnGyaCkzbhl6YcqmK/69prxPqtpx2+Km9al9sjL+rwMgHw4jE/C8/HQ3m1vBuL1fldbzd8mOueVJ92syqdEY4KJjSCde3mcRw2TA6szxedn+zwhZMps0XrqEsiUjnC1hw0TELC2Ek7uAAdzcheXv1BYLagspxpzSAoZZUsIzIq35MnFQ9DOrlNB30jq3L4pkhccKUAA8/ocvN1Rzx9QyOtERs4CVsJRK/DF71kPYrxYsGsm6RMh4cps5g1DOmM54Ly1ii0Hd3Y/BMk8VWFgBVmhqrkJCPBHAolwZaWzLR9Vb7bcWdX9NyUYE+uB2BKfuaeBUcjDljbYVY4DdtsVWvzRZdWnyUzDpjNl1Du3aloAjVJTNDpcIOVVhrHFF66lLfJL1zJr9PQ2nFJSBaKoDe+sAvLufZVHVzYh7W0h/c6AAZ+7Tvj6q9j68G/cTCS/3n1vLKHZwNi+P+pS0WkZNMBMUl+LDLuiE4omZy71r3UFMwNJV+VJ/GC5ixVUkBStsT4gGKh0Gm4Oy3qvq7Lbmq24nPdDuDR9deR11XzP4vFu3TYzfnIyiSVmgizUYGqkIXNdKTY9pgb9D2Ix5t0+NHkVzCdU03suWkkVZAoCONCn0T35gAeW38de43mf97sMOpSvj4aa1KYUm58USI7Wxxes03bAZdRzk6UtbzMaCQ6IxO0dy7X+XsjoD16hpsBeGz9dfzHj+R/Hp8nCxZRqkEDTaCKCSywjiaoMJ1TITE9eg7Jqnq8HL6gDwiZb0u0V0Rr/rmvqjxKuaLCX7ZWXTvAY+uvm3z8CP7nzVpngqrJpZKwWnCUjIviYVlirlGOzPLI3SMVyp/elvBUjjDkNhrtufFFErQ8pmdSlbK16toBHlt/HV8uHMX/vEGALkV3RJREiSlopxwdMXOZPLZ+ix+kAHpMKIk8UtE1ygtquttwxNhphrIZ1IBzjGF3IIGxGcBj6q8bHJBG8T9vdsoWrTFEuebEZuVxhhClH6P5Zo89OG9fwHNjtNQTpD0TG9PJLEYqvEY6Rlxy+ZZGfL0Aj62/bnQCXp//eeM4KzfQVJbgMQbUjlMFIm6TpcfWlZje7NBSV6IsEVmumWIbjiloUzQX9OzYdo8L1wjw2PrrpimONfmfNyzKklrgnEkSzT5QWYQW40YShyzqsRmMXbvVxKtGuYyMKaU1ugenLDm5Ily4iT14fP11Mx+xJv+zZ3MvnfdFqxU3a1W/FTB4m3Qfsyc1XUcdVhDeUDZXSFHHLQj/Y5jtC7ZqM0CXGwB4bP11i3LhOvzPGygYtiUBiwQV/4wFO0majijGsafHyRLu0yG6q35cL1rOpVxr2s5cM2jJYMCdc10Aj6q/blRpWJ//+dmm5psMl0KA2+AFRx9jMe2WbC4jQxnikd4DU8TwUjRVacgdlhmr3bpddzuJ9zXqr2xnxJfzP29RexdtjDVZqzkqa6PyvcojGrfkXiJ8SEtml/nYskicv0ivlxbqjemwUjMw5evdg8fUX9nOiC/lf94Q2i7MURk9nW1MSj5j8eAyV6y5CN2S6qbnw3vdA1Iwq+XOSCl663udN3IzLnrt+us25cI1+Z83SXQUldqQq0b5XOT17bGpLd6ssN1VMPf8c+jG8L3NeCnMdF+Ra3fRa9dft39/LuZ/3vwHoHrqGmQFafmiQw6eyzMxS05K4bL9uA+SKUQzCnSDkqOGokXyJvbgJ/BHI+qvY69//4rl20NsmK2ou2dTsyIALv/91/8n3P2Aao71WFGi8KKv1fRC5+J67Q/507/E/SOshqN5TsmYIjVt+kcjAx98iz/4SaojbIV1rexE7/C29HcYD/DX4a0rBOF5VTu7omsb11L/AWcVlcVZHSsqGuXLLp9ha8I//w3Mv+T4Ew7nTBsmgapoCrNFObIcN4pf/Ob/mrvHTGqqgAupL8qWjWPS9m/31jAe4DjA+4+uCoQoT/zOzlrNd3qd4SdphFxsUvYwGWbTWtISc3wNOWH+kHBMfc6kpmpwPgHWwqaSUG2ZWWheYOGQGaHB+eQ/kn6b3pOgLV+ODSn94wDvr8Bvb70/LLuiPPEr8OGVWfDmr45PZyccEmsVXZGe1pRNX9SU5+AVQkNTIVPCHF/jGmyDC9j4R9LfWcQvfiETmgMMUCMN1uNCakkweZsowdYobiMSlnKA93u7NzTXlSfe+SVbfnPQXmg9LpYAQxpwEtONyEyaueWM4FPjjyjG3uOaFmBTWDNgBXGEiQpsaWhnAqIijB07Dlsy3fUGeP989xbWkyf+FF2SNEtT1E0f4DYYVlxFlbaSMPIRMk/3iMU5pME2SIWJvjckciebkQuIRRyhUvkHg/iUljG5kzVog5hV7vIlCuBrmlhvgPfNHQM8lCf+FEGsYbMIBC0qC9a0uuy2wLXVbLBaP5kjHokCRxapkQyzI4QEcwgYHRZBp+XEFTqXFuNVzMtjXLJgX4gAid24Hjwc4N3dtVSe+NNiwTrzH4WVUOlDobUqr1FuAgYllc8pmzoVrELRHSIW8ViPxNy4xwjBpyR55I6J220qQTZYR4guvUICJiSpr9gFFle4RcF/OMB7BRiX8sSfhpNSO3lvEZCQfLUVTKT78Ek1LRLhWN+yLyTnp8qWUZ46b6vxdRGXfHVqx3eI75YaLa4iNNiK4NOW7wPW6lhbSOF9/M9qw8e/aoB3d156qTzxp8pXx5BKAsYSTOIIiPkp68GmTq7sZtvyzBQaRLNxIZ+paozHWoLFeExIhRBrWitHCAHrCF7/thhD8JhYz84wg93QRV88wLuLY8zF8sQ36qF1J455bOlgnELfshKVxYOXKVuKx0jaj22sczTQqPqtV/XDgpswmGTWWMSDw3ssyUunLLrVPGjYRsH5ggHeHSWiV8kT33ycFSfMgkoOK8apCye0J6VW6GOYvffgU9RWsukEi2kUV2nl4dOYUzRik9p7bcA4ggdJ53LxKcEe17B1R8eqAd7dOepV8sTXf5lhejoL85hUdhDdknPtKHFhljOT+bdq0hxbm35p2nc8+Ja1Iw+tJykgp0EWuAAZYwMVwac5KzYMslhvgHdHRrxKnvhTYcfKsxTxtTETkjHO7rr3zjoV25lAQHrqpV7bTiy2aXMmUhTBnKS91jhtR3GEoF0oLnWhWNnYgtcc4N0FxlcgT7yz3TgNIKkscx9jtV1ZKpWW+Ub1tc1eOv5ucdgpx+FJy9pgbLE7xDyXb/f+hLHVGeitHOi6A7ybo3sF8sS7w7cgdk0nJaOn3hLj3uyD0Zp5pazFIUXUpuTTU18d1EPkDoX8SkmWTnVIozEdbTcZjoqxhNHf1JrSS/AcvHjZ/SMHhL/7i5z+POsTUh/8BvNfYMTA8n+yU/MlTZxSJDRStqvEuLQKWwDctMTQogUDyQRoTQG5Kc6oQRE1yV1jCA7ri7jdZyK0sYTRjCR0Hnnd+y7nHxNgTULqw+8wj0mQKxpYvhjm9uSUxg+TTy7s2GtLUGcywhXSKZN275GsqlclX90J6bRI1aouxmgL7Q0Nen5ziM80SqMIo8cSOo+8XplT/5DHNWsSUr/6lLN/QQ3rDyzLruEW5enpf7KqZoShEduuSFOV7DLX7Ye+GmXb6/hnNNqKsVXuMDFpb9Y9eH3C6NGEzuOuI3gpMH/I6e+zDiH1fXi15t3vA1czsLws0TGEtmPEJdiiFPwlwKbgLHAFk4P6ZyPdymYYHGE0dutsChQBl2JcBFlrEkY/N5bQeXQ18gjunuMfMfsBlxJSx3niO485fwO4fGD5T/+3fPQqkneWVdwnw/3bMPkW9Wbqg+iC765Zk+xcT98ibKZc2EdgHcLoF8cSOo/Oc8fS+OyEULF4g4sJqXVcmfMfsc7A8v1/yfGXmL9I6Fn5pRwZhsPv0TxFNlAfZCvG+Oohi82UC5f/2IsJo0cTOm9YrDoKhFPEUr/LBYTUNht9zelHXDqwfPCIw4owp3mOcIQcLttWXFe3VZ/j5H3cIc0G6oPbCR+6Y2xF2EC5cGUm6wKC5tGEzhsWqw5hNidUiKX5gFWE1GXh4/Qplw4sVzOmx9QxU78g3EF6wnZlEN4FzJ1QPSLEZz1KfXC7vd8ssGdIbNUYpVx4UapyFUHzJoTOo1McSkeNn1M5MDQfs4qQuhhX5vQZFw8suwWTcyYTgioISk2YdmkhehG4PkE7w51inyAGGaU+uCXADabGzJR1fn3lwkty0asIo8cROm9Vy1g0yDxxtPvHDAmpu+PKnM8Ix1wwsGw91YJqhteaWgjYBmmQiebmSpwKKzE19hx7jkzSWOm66oPbzZ8Yj6kxVSpYjVAuvLzYMCRo3oTQecOOjjgi3NQ4l9K5/hOGhNTdcWVOTrlgYNkEXINbpCkBRyqhp+LdRB3g0OU6rMfW2HPCFFMV9nSp+uB2woepdbLBuJQyaw/ZFysXrlXwHxI0b0LovEkiOpXGA1Ijagf+KUNC6rKNa9bQnLFqYNkEnMc1uJrg2u64ELPBHpkgWbmwKpJoDhMwNbbGzAp7Yg31wS2T5rGtzit59PrKhesWG550CZpHEzpv2NGRaxlNjbMqpmEIzygJqQfjypycs2pg2cS2RY9r8HUqkqdEgKTWtWTKoRvOBPDYBltja2SO0RGjy9UHtxwRjA11ujbKF+ti5cIR9eCnxUg6owidtyoU5tK4NLji5Q3HCtiyF2IqLGYsHViOXTXOYxucDqG0HyttqYAKqYo3KTY1ekyDXRAm2AWh9JmsVh/ccg9WJ2E8YjG201sPq5ULxxX8n3XLXuMInbft2mk80rRGjCGctJ8/GFdmEQ9Ug4FlE1ll1Y7jtiraqm5Fe04VV8lvSVBL8hiPrfFVd8+7QH3Qbu2ipTVi8cvSGivc9cj8yvH11YMHdNSERtuOslM97feYFOPKzGcsI4zW0YGAbTAOaxCnxdfiYUmVWslxiIblCeAYr9VYR1gM7GmoPrilunSxxeT3DN/2eBQ9H11+nk1adn6VK71+5+Jfct4/el10/7KBZfNryUunWSCPxPECk1rdOv1WVSrQmpC+Tl46YD3ikQYcpunSQgzVB2VHFhxHVGKDgMEY5GLlQnP7FMDzw7IacAWnO6sBr12u+XanW2AO0wQ8pknnFhsL7KYIqhkEPmEXFkwaN5KQphbkUmG72wgw7WSm9RiL9QT925hkjiVIIhphFS9HKI6/8QAjlpXqg9W2C0apyaVDwKQwrwLY3j6ADR13ZyUNByQXHQu6RY09Hu6zMqXRaNZGS/KEJs0cJEe9VH1QdvBSJv9h09eiRmy0V2uJcqHcShcdvbSNg5fxkenkVprXM9rDVnX24/y9MVtncvbKY706anNl3ASll9a43UiacVquXGhvq4s2FP62NGKfQLIQYu9q1WmdMfmUrDGt8eDS0cXozH/fjmUH6Jruvm50hBDSaEU/2Ru2LEN/dl006TSc/g7tfJERxGMsgDUEr104pfWH9lQaN+M4KWQjwZbVc2rZVNHsyHal23wZtIs2JJqtIc/WLXXRFCpJkfE9jvWlfFbsNQ9pP5ZBS0zKh4R0aMFj1IjTcTnvi0Zz2rt7NdvQb2mgbju1plsH8MmbnEk7KbK0b+wC2iy3aX3szW8xeZvDwET6hWZYwqTXSSG+wMETKum0Dq/q+x62gt2ua2ppAo309TRk9TPazfV3qL9H8z7uhGqGqxNVg/FKx0HBl9OVUORn8Q8Jx9gFttGQUDr3tzcXX9xGgN0EpzN9mdZ3GATtPhL+CjxFDmkeEU6x56kqZRusLzALXVqkCN7zMEcqwjmywDQ6OhyUe0Xao1Qpyncrg6wKp9XfWDsaZplElvQ/b3sdweeghorwBDlHzgk1JmMc/wiERICVy2VJFdMjFuLQSp3S0W3+sngt2njwNgLssFGVQdJ0tu0KH4ky1LW4yrbkuaA6Iy9oz/qEMMXMMDWyIHhsAyFZc2peV9hc7kiKvfULxCl9iddfRK1f8kk9qvbdOoBtOg7ZkOZ5MsGrSHsokgLXUp9y88smniwWyuFSIRVmjplga3yD8Uij5QS1ZiM4U3Qw5QlSm2bXjFe6jzzBFtpg+/YBbLAWG7OPynNjlCw65fukGNdkJRf7yM1fOxVzbxOJVocFoYIaGwH22mIQkrvu1E2nGuebxIgW9U9TSiukPGU+Lt++c3DJPKhyhEEbXCQLUpae2exiKy6tMPe9mDRBFCEMTWrtwxN8qvuGnt6MoihKWS5NSyBhbH8StXoAz8PLOrRgLtOT/+4vcu+7vDLnqNvztOq7fmd8sMmY9Xzn1zj8Dq8+XVdu2Nv0IIySgEdQo3xVHps3Q5i3fLFsV4aiqzAiBhbgMDEd1uh8qZZ+lwhjkgokkOIv4xNJmyncdfUUzgB4oFMBtiu71Xumpz/P+cfUP+SlwFExwWW62r7b+LSPxqxn/gvMZ5z9C16t15UbNlq+jbGJtco7p8wbYlL4alSyfWdeuu0j7JA3JFNuVAwtst7F7FhWBbPFNKIUORndWtLraFLmMu7KFVDDOzqkeaiN33YAW/r76wR4XDN/yN1z7hejPau06EddkS/6XThfcz1fI/4K736fO48vlxt2PXJYFaeUkFS8U15XE3428xdtn2kc8GQlf1vkIaNRRnOMvLTWrZbElEHeLWi1o0dlKPAh1MVgbbVquPJ5+Cr8LU5/H/+I2QlHIU2ClXM9G8v7Rr7oc/hozfUUgsPnb3D+I+7WF8kNO92GY0SNvuxiE+2Bt8prVJTkzE64sfOstxuwfxUUoyk8VjcTlsqe2qITSFoSj6Epd4KsT6BZOWmtgE3hBfir8IzZDwgV4ZTZvD8VvPHERo8v+vL1DASHTz/i9OlKueHDjK5Rnx/JB1Vb1ioXdBra16dmt7dgik10yA/FwJSVY6XjA3oy4SqM2frqDPPSRMex9qs3XQtoWxMj7/Er8GWYsXgjaVz4OYumP2+9kbxvny/6kvWsEBw+fcb5bInc8APdhpOSs01tEqIkoiZjbAqKMruLbJYddHuHFRIyJcbdEdbl2sVLaySygunutBg96Y2/JjKRCdyHV+AEFtTvIpbKIXOamknYSiB6KV/0JetZITgcjjk5ZdaskBtWO86UF0ap6ozGXJk2WNiRUlCPFir66lzdm/SLSuK7EUdPz8f1z29Skq6F1fXg8+5UVR6bszncP4Tn4KUkkdJ8UFCY1zR1i8RmL/qQL3rlei4THG7OODlnKko4oI01kd3CaM08Ia18kC3GNoVaO9iDh+hWxSyTXFABXoau7Q6q9OxYg/OVEMw6jdbtSrJ9cBcewGmaZmg+bvkUnUUaGr+ZfnMH45Ivevl61hMcXsxYLFTu1hTm2zViCp7u0o5l+2PSUh9bDj6FgYypufBDhqK2+oXkiuHFHR3zfj+9PtA8oR0xnqX8qn+sx3bFODSbbF0X8EUvWQ8jBIcjo5bRmLOljDNtcqNtOe756h3l0VhKa9hDd2l1eqmsnh0MNMT/Cqnx6BInumhLT8luljzQ53RiJeA/0dxe5NK0o2fA1+GLXr6eNQWHNUOJssQaTRlGpLHKL9fD+IrQzTOMZS9fNQD4AnRNVxvTdjC+fJdcDDWQcyB00B0t9BDwTxXgaAfzDZ/DBXzRnfWMFRwuNqocOmX6OKNkY63h5n/fFcB28McVHqnXZVI27K0i4rDLNE9lDKV/rT+udVbD8dFFu2GGZ8mOt0kAXcoX3ZkIWVtw+MNf5NjR2FbivROHmhV1/pj2egv/fMGIOWTIWrV3Av8N9imV9IWml36H6cUjqEWNv9aNc+veb2sH46PRaHSuMBxvtW+twxctq0z+QsHhux8Q7rCY4Ct8lqsx7c6Sy0dl5T89rIeEuZKoVctIk1hNpfavER6yyH1Vvm3MbsUHy4ab4hWr/OZPcsRBphnaV65/ZcdYPNNwsjN/djlf9NqCw9U5ExCPcdhKxUgLSmfROpLp4WSUr8ojdwbncbvCf+a/YzRaEc6QOvXcGO256TXc5Lab9POvB+AWY7PigWYjzhifbovuunzRawsO24ZqQQAqguBtmpmPB7ysXJfyDDaV/aPGillgz1MdQg4u5MYaEtBNNHFjkRlSpd65lp4hd2AVPTfbV7FGpyIOfmNc/XVsPfg7vzaS/3nkvLL593ANLvMuRMGpQIhiF7kUEW9QDpAUbTWYBcbp4WpacHHY1aacqQyjGZS9HI3yCBT9kUZJhVOD+zUDvEH9ddR11fzPcTDQ5TlgB0KwqdXSavk9BC0pKp0WmcuowSw07VXmXC5guzSa4p0UvRw2lbDiYUx0ExJJRzWzi6Gm8cnEkfXXsdcG/M/jAJa0+bmCgdmQ9CYlNlSYZOKixmRsgiFxkrmW4l3KdFKv1DM8tk6WxPYJZhUUzcd8Kdtgrw/gkfXXDT7+avmfVak32qhtkg6NVdUS5wgkru1YzIkSduTW1FDwVWV3JQVJVuieTc0y4iDpFwc7/BvSalvKdQM8sv662cevz/+8sQVnjVAT0W2wLllw1JiMhJRxgDjCjLQsOzSFSgZqx7lAW1JW0e03yAD3asC+GD3NbQhbe+mN5GXH1F83KDOM4n/e5JIuH4NpdQARrFPBVptUNcjj4cVMcFSRTE2NpR1LEYbYMmfWpXgP9KejaPsLUhuvLCsVXznAG9dfx9SR1ud/3hZdCLHb1GMdPqRJgqDmm76mHbvOXDtiO2QPUcKo/TWkQ0i2JFXpBoo7vij1i1Lp3ADAo+qvG3V0rM//vFnnTE4hxd5Ka/Cor5YEdsLVJyKtDgVoHgtW11pWSjolPNMnrlrVj9Fv2Qn60twMwKPqr+N/wvr8z5tZcDsDrv06tkqyzESM85Ycv6XBWA2birlNCXrI6VbD2lx2L0vQO0QVTVVLH4SE67fgsfVXv8n7sz7/85Z7cMtbE6f088wSaR4kCkCm10s6pKbJhfqiUNGLq+0gLWC6eUAZFPnLjwqtKd8EwGvWX59t7iPW4X/eAN1svgRVSY990YZg06BD1ohLMtyFTI4pKTJsS9xREq9EOaPWiO2gpms7397x6nQJkbh+Fz2q/rqRROX6/M8bJrqlVW4l6JEptKeUFuMYUbtCQ7CIttpGc6MY93x1r1vgAnRXvY5cvwWPqb9uWQm+lP95QxdNMeWhOq1x0Db55C7GcUv2ZUuN6n8iKzsvOxibC//Yfs9Na8r2Rlz02vXXDT57FP/zJi66/EJSmsJKa8QxnoqW3VLQ+jZVUtJwJ8PNX1NQCwfNgdhhHD9on7PdRdrdGPF28rJr1F+3LBdeyv+8yYfLoMYet1vX4upNAjVvwOUWnlNXJXlkzk5Il6kqeoiL0C07qno+/CYBXq/+utlnsz7/Mzvy0tmI4zm4ag23PRN3t/CWryoUVJGm+5+K8RJ0V8Hc88/XHUX/HfiAq7t+BH+x6v8t438enWmdJwFA6ZINriLGKv/95f8lT9/FnyA1NMVEvQyaXuu+gz36f/DD73E4pwqpLcvm/o0Vle78n//+L/NPvoefp1pTJye6e4A/D082FERa5/opeH9zpvh13cNm19/4v/LDe5xMWTi8I0Ta0qKlK27AS/v3/r+/x/2GO9K2c7kVMonDpq7//jc5PKCxeNPpFVzaRr01wF8C4Pu76hXuX18H4LduTr79guuFD3n5BHfI+ZRFhY8w29TYhbbLi/bvBdqKE4fUgg1pBKnV3FEaCWOWyA+m3WpORZr/j+9TKJtW8yBTF2/ZEODI9/QavHkVdGFp/Pjn4Q+u5hXapsP5sOH+OXXA1LiKuqJxiMNbhTkbdJTCy4llEt6NnqRT4dhg1V3nbdrm6dYMecA1yTOL4PWTE9L5VzPFlLBCvlG58AhehnN4uHsAYinyJ+AZ/NkVvELbfOBUuOO5syBIEtiqHU1k9XeISX5bsimrkUUhnGDxourN8SgUsCZVtKyGbyGzHXdjOhsAvOAswSRyIBddRdEZWP6GZhNK/yjwew9ehBo+3jEADu7Ay2n8mDc+TS7awUHg0OMzR0LABhqLD4hJEh/BEGyBdGlSJoXYXtr+3HS4ijzVpgi0paWXtdruGTknXBz+11qT1Q2inxaTzQCO46P3lfLpyS4fou2PH/PupwZgCxNhGlj4IvUuWEsTkqMWm6i4xCSMc9N1RDQoCVcuGItJ/MRWefais+3synowi/dESgJjkilnWnBTGvRWmaw8oR15257t7CHmCf8HOn7cwI8+NQBXMBEmAa8PMRemrNCEhLGEhDQKcGZWS319BX9PFBEwGTbRBhLbDcaV3drFcDqk5kCTd2JF1Wp0HraqBx8U0wwBTnbpCadwBA/gTH/CDrcCs93LV8E0YlmmcyQRQnjBa8JESmGUfIjK/7fkaDJpmD2QptFNVJU1bbtIAjjWQizepOKptRjbzR9Kag6xZmMLLjHOtcLT3Tx9o/0EcTT1XN3E45u24AiwEypDJXihKjQxjLprEwcmRKclaDNZCVqr/V8mYWyFADbusiY5hvgFoU2vio49RgJLn5OsReRFN6tabeetiiy0V7KFHT3HyZLx491u95sn4K1QQSPKM9hNT0wMVvAWbzDSVdrKw4zRjZMyJIHkfq1VAVCDl/bUhNKlGq0zGr05+YAceXVPCttVk0oqjVwMPt+BBefx4yPtGVkUsqY3CHDPiCM5ngupUwCdbkpd8kbPrCWHhkmtIKLEetF2499eS1jZlIPGYnlcPXeM2KD9vLS0bW3ktYNqUllpKLn5ZrsxlIzxvDu5eHxzGLctkZLEY4PgSOg2IUVVcUONzUDBEpRaMoXNmUc0tFZrTZquiLyKxrSm3DvIW9Fil+AkhXu5PhEPx9mUNwqypDvZWdKlhIJQY7vn2OsnmBeOWnYZ0m1iwbbw1U60by5om47iHRV6fOgzjMf/DAZrlP40Z7syxpLK0lJ0gqaAK1c2KQKu7tabTXkLFz0sCftuwX++MyNeNn68k5Buq23YQhUh0SNTJa1ioQ0p4nUG2y0XilF1JqODqdImloPS4Bp111DEWT0jJjVv95uX9BBV7eB3bUWcu0acSVM23YZdd8R8UbQUxJ9wdu3oMuhdt929ME+mh6JXJ8di2RxbTi6TbrDquqV4aUKR2iwT6aZbyOwEXN3DUsWr8Hn4EhwNyHuXHh7/pdaUjtR7vnDh/d8c9xD/s5f501eQ1+CuDiCvGhk1AN/4Tf74RfxPwD3toLarR0zNtsnPzmS64KIRk861dMWCU8ArasG9T9H0ZBpsDGnjtAOM2+/LuIb2iIUGXNgl5ZmKD/Tw8TlaAuihaFP5yrw18v4x1898zIdP+DDAX1bM3GAMvPgRP/cJn3zCW013nrhHkrITyvYuwOUkcHuKlRSW5C6rzIdY4ppnF7J8aAJbQepgbJYBjCY9usGXDKQxq7RZfh9eg5d1UHMVATRaD/4BHK93/1iAgYZ/+jqPn8Dn4UExmWrpa3+ZOK6MvM3bjwfzxNWA2dhs8+51XHSPJiaAhGSpWevEs5xHLXcEGFXYiCONySH3fPWq93JIsBiSWvWyc3CAN+EcXoT7rCSANloPPoa31rt/5PUA/gp8Q/jDD3hyrjzlR8VkanfOvB1XPubt17vzxAfdSVbD1pzAnfgyF3ycadOTOTXhpEUoLC1HZyNGW3dtmjeXgr2r56JNmRwdNNWaQVBddd6rh4MhviEB9EFRD/7RGvePvCbwAL4Mx/D6M541hHO4D3e7g6PafdcZVw689z7NGTwo5om7A8sPhccT6qKcl9NJl9aM/9kX+e59Hh1yPqGuCCZxuITcsmNaJ5F7d0q6J3H48TO1/+M57085q2icdu2U+W36Ldllz9Agiv4YGljoEN908EzvDOrBF98/vtJwCC/BF2AG75xxEmjmMIcjxbjoaxqOK3/4hPOZzhMPBpYPG44CM0dTVm1LjLtUWWVz1Bcf8tEx0zs8O2A2YVHRxKYOiy/aOVoAaMu0i7ubu43njjmd4ibMHU1sIDHaQNKrZND/FZYdk54oCXetjq7E7IVl9eAL7t+oHnwXXtLx44czzoRFHBztYVwtH1d+NOMkupZ5MTM+gUmq90X+Bh9zjRlmaQ+m7YMqUL/veemcecAtOJ0yq1JnVlN27di2E0+Klp1tAJ4KRw1eMI7aJjsO3R8kPSI3fUFXnIOfdQe86sIIVtWDL7h//Ok6vj8vwDk08NEcI8zz7OhBy+WwalzZeZ4+0XniRfst9pAJqQHDGLzVQ2pheZnnv1OWhwO43/AgcvAEXEVVpa4db9sGvNK8wjaENHkfFQ4Ci5i7dqnQlPoLQrHXZDvO3BIXZbJOBrOaEbML6sFL798I4FhKihjHMsPjBUZYCMFr6nvaArxqXPn4lCa+cHfSa2cP27g3Z3ziYTRrcbQNGLQmGF3F3cBdzzzX7AILx0IB9rbwn9kx2G1FW3Inic+ZLIsVvKR8Zwfj0l1fkqo8LWY1M3IX14OX3r9RKTIO+d9XzAI8qRPGPn/4NC2n6o4rN8XJ82TOIvuVA8zLKUHRFgBCetlDZlqR1gLKjS39xoE7Bt8UvA6BxuEDjU3tFsEijgA+615tmZkXKqiEENrh41iLDDZNq4pKTWR3LZfnos81LOuNa15cD956vLMsJd1rqYp51gDUQqMYm2XsxnUhD2jg1DM7SeuJxxgrmpfISSXVIJIS5qJJSvJPEQ49DQTVIbYWJ9QWa/E2+c/oPK1drmC7WSfJRNKBO5Yjvcp7Gc3dmmI/Xh1kDTEuiSnWqQf37h+fTMhGnDf6dsS8SQfQWlqqwXXGlc/PEZ/SC5mtzIV0nAshlQdM/LvUtYutrEZ/Y+EAFtq1k28zQhOwLr1AIeANzhF8t9qzTdZf2qRKO6MWE9ohBYwibbOmrFtNmg3mcS+tB28xv2uKd/agYCvOP+GkSc+0lr7RXzyufL7QbkUpjLjEWFLqOIkAGu2B0tNlO9Eau2W1qcOUvVRgKzypKIQZ5KI3q0MLzqTNRYqiZOqmtqloIRlmkBHVpHmRYV6/HixbO6UC47KOFJnoMrVyr7wYz+SlW6GUaghYbY1I6kkxA2W1fSJokUdSh2LQ1GAimRGm0MT+uu57H5l7QgOWxERpO9moLRPgTtquWCfFlGlIjQaRly9odmzMOWY+IBO5tB4sW/0+VWGUh32qYk79EidWKrjWuiLpiVNGFWFRJVktyeXWmbgBBzVl8anPuXyNJlBJOlKLTgAbi/EYHVHxWiDaVR06GnHQNpJcWcK2jJtiCfG2sEHLzuI66sGrMK47nPIInPnu799935aOK2cvmvubrE38ZzZjrELCmXM2hM7UcpXD2oC3+ECVp7xtIuxptJ0jUr3sBmBS47TVxlvJ1Sqb/E0uLdvLj0lLr29ypdd/eMX3f6lrxGlKwKQxEGvw0qHbkbwrF3uHKwVENbIV2wZ13kNEF6zD+x24aLNMfDTCbDPnEikZFyTNttxWBXDaBuM8KtI2rmaMdUY7cXcUPstqTGvBGSrFWIpNMfbdea990bvAOC1YX0qbc6smDS1mPxSJoW4fwEXvjMmhlijDRq6qale6aJEuFGoppYDoBELQzLBuh/mZNx7jkinv0EtnUp50lO9hbNK57lZaMAWuWR5Yo9/kYwcYI0t4gWM47Umnl3YmpeBPqSyNp3K7s2DSAS/39KRuEN2bS4xvowV3dFRMx/VFcp2Yp8w2nTO9hCXtHG1kF1L4KlrJr2wKfyq77R7MKpFKzWlY9UkhYxyHWW6nBWPaudvEAl3CGcNpSXPZ6R9BbBtIl6cHL3gIBi+42CYXqCx1gfGWe7Ap0h3luyXdt1MKy4YUT9xSF01G16YEdWsouW9mgDHd3veyA97H+Ya47ZmEbqMY72oPztCGvK0onL44AvgC49saZKkWRz4veWljE1FHjbRJaWv6ZKKtl875h4CziFCZhG5rx7tefsl0aRT1bMHZjm8dwL/6u7wCRysaQblQoG5yAQN5zpatMNY/+yf8z+GLcH/Qn0iX2W2oEfXP4GvwQHuIL9AYGnaO3zqAX6946nkgqZNnUhx43DIdQtMFeOPrgy/y3Yd85HlJWwjLFkU3kFwq28xPnuPhMWeS+tDLV9Otllq7pQCf3uXJDN9wFDiUTgefHaiYbdfi3b3u8+iY6TnzhgehI1LTe8lcd7s1wJSzKbahCRxKKztTLXstGAiu3a6rPuQs5pk9TWAan5f0BZmGf7Ylxzzk/A7PAs4QPPPAHeFQ2hbFHszlgZuKZsJcUmbDC40sEU403cEjczstOEypa+YxevL4QBC8oRYqWdK6b7sK25tfE+oDZgtOQ2Jg8T41HGcBE6fTWHn4JtHcu9S7uYgU5KSCkl/mcnq+5/YBXOEr6lCUCwOTOM1taOI8mSxx1NsCXBEmLKbMAg5MkwbLmpBaFOPrNSlO2HnLiEqW3tHEwd8AeiQLmn+2gxjC3k6AxREqvKcJbTEzlpLiw4rNZK6oJdidbMMGX9FULKr0AkW+2qDEPBNNm5QAt2Ik2nftNWHetubosHLo2nG4vQA7GkcVCgVCgaDixHqo9UUn1A6OshapaNR/LPRYFV8siT1cCtJE0k/3WtaNSuUZYKPnsVIW0xXWnMUxq5+En4Kvw/MqQmVXnAXj9Z+9zM98zM/Agy7F/qqj2Nh67b8HjFnPP3iBn/tkpdzwEJX/whIcQUXOaikeliCRGUk7tiwF0rItwMEhjkZ309hikFoRAmLTpEXWuHS6y+am/KB/fM50aLEhGnSMwkpxzOov4H0AvgovwJ1iGzDLtJn/9BU+fAINfwUe6FHSLhu83viV/+/HrOePX+STT2B9uWGbrMHHLldRBlhS/CJQmcRxJFqZica01XixAZsYiH1uolZxLrR/SgxVIJjkpQP4PE9sE59LKLr7kltSBogS5tyszzH8Fvw8/AS8rNOg0xUS9fIaHwb+6et8Q/gyvKRjf5OusOzGx8evA/BP4IP11uN/grca5O0lcsPLJ5YjwI4QkJBOHa0WdMZYGxPbh2W2nR9v3WxEWqgp/G3+6VZbRLSAAZ3BhdhAaUL33VUSw9yjEsvbaQ9u4A/gGXwZXoEHOuU1GSj2chf+Mo+f8IcfcAxfIKVmyunRbYQVnoevwgfw3TXXcw++xNuP4fhyueEUNttEduRVaDttddoP0eSxLe2LENk6itYxlrxBNBYrNNKSQmeaLcm9c8UsaB5WyO6675yyQIAWSDpBVoA/gxmcwEvwoDv0m58UE7gHn+fJOa8/Ywan8EKRfjsopF83eCglX/Sfr7OeaRoQfvt1CGvIDccH5BCvw1sWIzRGC/66t0VTcLZQZtm6PlAasbOJ9iwWtUo7biktTSIPxnR24jxP1ZKaqq+2RcXM9OrBAm/AAs7hDJ5bNmGb+KIfwCs8a3jnjBrOFeMjHSCdbKr+2uOLfnOd9eiA8Hvvwwq54VbP2OqwkB48Ytc4YEOiH2vTXqodabfWEOzso4qxdbqD5L6tbtNPECqbhnA708DZH4QOJUXqScmUlks7Ot6FBuZw3n2mEbaUX7kDzxHOOQk8nKWMzAzu6ZZ8sOFw4RK+6PcuXo9tB4SbMz58ApfKDXf3szjNIIbGpD5TKTRxGkEMLjLl+K3wlWXBsCUxIDU+jbOiysESqAy1MGUJpXgwbTWzNOVEziIXZrJ+VIztl1PUBxTSo0dwn2bOmfDRPD3TRTGlfbCJvO9KvuhL1hMHhB9wPuPRLGHcdOWG2xc0U+5bQtAJT0nRTewXL1pgk2+rZAdeWmz3jxAqfNQQdzTlbF8uJ5ecEIWvTkevAHpwz7w78QujlD/Lr491bD8/1vhM2yrUQRrWXNQY4fGilfctMWYjL72UL/qS9eiA8EmN88nbNdour+PBbbAjOjIa4iBhfFg6rxeKdEGcL6p3EWR1Qq2Qkhs2DrnkRnmN9tG2EAqmgPw6hoL7Oza7B+3SCrR9tRftko+Lsf2F/mkTndN2LmzuMcKTuj/mX2+4Va3ki16+nnJY+S7MefpkidxwnV+4wkXH8TKnX0tsYzYp29DOOoSW1nf7nTh2akYiWmcJOuTidSaqESrTYpwjJJNVGQr+rLI7WsqerHW6Kp/oM2pKuV7T1QY9gjqlZp41/WfKpl56FV/0kvXQFRyeQ83xaTu5E8p5dNP3dUF34ihyI3GSpeCsywSh22ZJdWto9winhqifb7VRvgktxp13vyjrS0EjvrRfZ62uyqddSWaWYlwTPAtJZ2oZ3j/Sgi/mi+6vpzesfAcWNA0n8xVyw90GVFGuZjTXEQy+6GfLGLMLL523f5E0OmxVjDoOuRiH91RKU+vtoCtH7TgmvBLvtFXWLW15H9GTdVw8ow4IlRLeHECN9ym1e9K0I+Cbnhgv4Yu+aD2HaQJ80XDqOzSGAV4+4yCqBxrsJAX6ZTIoX36QnvzhhzzMfFW2dZVLOJfo0zbce5OvwXMFaZ81mOnlTVXpDZsQNuoYWveketKb5+6JOOsgX+NTm7H49fUTlx+WLuWL7qxnOFh4BxpmJx0p2gDzA/BUARuS6phR+pUsY7MMboAHx5xNsSVfVZcYSwqCKrqon7zM+8ecCkeS4nm3rINuaWvVNnMRI1IRpxTqx8PZUZ0Br/UEduo3B3hNvmgZfs9gQPj8vIOxd2kndir3awvJ6BLvoUuOfFWNYB0LR1OQJoUySKb9IlOBx74q1+ADC2G6rOdmFdJcD8BkfualA+BdjOOzP9uUhGUEX/TwhZsUduwRr8wNuXKurCixLBgpQI0mDbJr9dIqUuV+92ngkJZ7xduCk2yZKbfWrH1VBiTg9VdzsgRjW3CVXCvAwDd+c1z9dWw9+B+8MJL/eY15ZQ/HqvTwVdsZn5WQsgRRnMaWaecu3jFvMBEmgg+FJFZsnSl0zjB9OqPYaBD7qmoVyImFvzi41usesV0julaAR9dfR15Xzv9sEruRDyk1nb+QaLU67T885GTls6YgcY+UiMa25M/pwGrbCfzkvR3e0jjtuaFtnwuagHTSb5y7boBH119HXhvwP487jJLsLJ4XnUkHX5sLbS61dpiAXRoZSCrFJ+EjpeU3puVfitngYNo6PJrAigKktmwjyQdZpfq30mmtulaAx9Zfx15Xzv+cyeuiBFUs9zq8Kq+XB9a4PVvph3GV4E3y8HENJrN55H1X2p8VyqSKwVusJDKzXOZzplWdzBUFK9e+B4+uv468xvI/b5xtSAkBHQaPvtqWzllVvEOxPbuiE6+j2pvjcKsbvI7txnRErgfH7LdXqjq0IokKzga14GzQ23SSbCQvO6r+Or7SMIr/efOkkqSdMnj9mBx2DRsiY29Uj6+qK9ZrssCKaptR6HKURdwUYeUWA2kPzVKQO8ku2nU3Anhs/XWkBx3F/7wJtCTTTIKftthue1ty9xvNYLY/zo5KSbIuKbXpbEdSyeRyYdAIwKY2neyoc3+k1XUaufYga3T9daMUx/r8z1s10ITknIO0kuoMt+TB8jK0lpayqqjsJ2qtXAYwBU932zinimgmd6mTRDnQfr88q36NAI+tv24E8Pr8zxtasBqx0+xHH9HhlrwsxxNUfKOHQaZBITNf0uccj8GXiVmXAuPEAKSdN/4GLHhs/XWj92dN/uetNuBMnVR+XWDc25JLjo5Mg5IZIq226tmCsip2zZliL213YrTlL2hcFjpCduyim3M7/eB16q/blQsv5X/esDRbtJeabLIosWy3ycavwLhtxdWzbMmHiBTiVjJo6lCLjXZsi7p9PEPnsq6X6wd4bP11i0rD5fzPm/0A6brrIsllenZs0lCJlU4abakR59enZKrKe3BZihbTxlyZ2zl1+g0wvgmA166/bhwDrcn/7Ddz0eWZuJvfSESug6NzZsox3Z04FIxz0mUjMwVOOVTq1CQ0AhdbBGVdjG/CgsfUX7esJl3K/7ytWHRv683praW/8iDOCqWLLhpljDY1ZpzK75QiaZoOTpLKl60auHS/97oBXrv+umU9+FL+5+NtLFgjqVLCdbmj7pY5zPCPLOHNCwXGOcLquOhi8CmCWvbcuO73XmMUPab+ug3A6/A/78Bwe0bcS2+tgHn4J5pyS2WbOck0F51Vq3LcjhLvZ67p1ABbaL2H67bg78BfjKi/jr3+T/ABV3ilLmNXTI2SpvxWBtt6/Z//D0z/FXaGbSBgylzlsEGp+5//xrd4/ae4d8DUUjlslfIYS3t06HZpvfQtvv0N7AHWqtjP2pW08QD/FLy//da38vo8PNlKHf5y37Dxdfe/oj4kVIgFq3koLReSR76W/bx//n9k8jonZxzWTANVwEniDsg87sOSd/z7//PvMp3jQiptGVWFX2caezzAXwfgtzYUvbr0iozs32c3Uge7varH+CNE6cvEYmzbPZ9hMaYDdjK4V2iecf6EcEbdUDVUARda2KzO/JtCuDbNQB/iTeL0EG1JSO1jbXS+nLxtPMDPw1fh5+EPrgSEKE/8Gry5A73ui87AmxwdatyMEBCPNOCSKUeRZ2P6Myb5MRvgCHmA9ywsMifU+AYXcB6Xa5GibUC5TSyerxyh0j6QgLVpdyhfArRTTLqQjwe4HOD9s92D4Ap54odXAPBWLAwB02igG5Kkc+piN4lvODIFGAZgT+EO4Si1s7fjSR7vcQETUkRm9O+MXyo9OYhfe4xt9STQ2pcZRLayCV90b4D3jR0DYAfyxJ+eywg2IL7NTMXna7S/RpQ63JhWEM8U41ZyQGjwsVS0QBrEKLu8xwZsbi4wLcCT+OGidPIOCe1PiSc9Qt+go+vYqB7cG+B9d8cAD+WJPz0Am2gxXgU9IneOqDpAAXOsOltVuMzpdakJXrdPCzXiNVUpCeOos5cxnpQT39G+XVLhs1osQVvJKPZyNq8HDwd4d7pNDuWJPxVX7MSzqUDU6gfadKiNlUFTzLeFHHDlzO4kpa7aiKhBPGKwOqxsBAmYkOIpipyXcQSPlRTf+Tii0U3EJGaZsDER2qoB3h2hu0qe+NNwUooYU8y5mILbJe6OuX+2FTKy7bieTDAemaQyQ0CPthljSWO+xmFDIYiESjM5xKd6Ik5lvLq5GrQ3aCMLvmCA9wowLuWJb9xF59hVVP6O0CrBi3ZjZSNOvRy+I6klNVRJYRBaEzdN+imiUXQ8iVF8fsp+W4JXw7WISW7fDh7lptWkCwZ4d7QTXyBPfJMYK7SijjFppGnlIVJBJBYj7eUwtiP1IBXGI1XCsjNpbjENVpSAJ2hq2LTywEly3hUYazt31J8w2+aiLx3g3fohXixPfOMYm6zCGs9LVo9MoW3MCJE7R5u/WsOIjrqBoHUO0bJE9vxBpbhsd3+Nb4/vtPCZ4oZYCitNeYuC/8UDvDvy0qvkiW/cgqNqRyzqSZa/s0mqNGjtKOoTm14zZpUauiQgVfqtQiZjq7Q27JNaSK5ExRcrGCXO1FJYh6jR6CFqK7bZdQZ4t8g0rSlPfP1RdBtqaa9diqtzJkQ9duSryi2brQXbxDwbRUpFMBHjRj8+Nt7GDKgvph9okW7LX47gu0SpGnnFQ1S1lYldOsC7hYteR574ZuKs7Ei1lBsfdz7IZoxzzCVmmVqaSySzQbBVAWDek+N4jh9E/4VqZrJjPwiv9BC1XcvOWgO8275CVyBPvAtTVlDJfZkaZGU7NpqBogAj/xEHkeAuJihWYCxGN6e8+9JtSegFXF1TrhhLGP1fak3pebgPz192/8gB4d/6WT7+GdYnpH7hH/DJzzFiYPn/vjW0SgNpTNuPIZoAEZv8tlGw4+RLxy+ZjnKa5NdFoC7UaW0aduoYse6+bXg1DLg6UfRYwmhGEjqPvF75U558SANrElK/+MdpXvmqBpaXOa/MTZaa1DOcSiLaw9j0NNNst3c+63c7EKTpkvKHzu6bPbP0RkuHAVcbRY8ijP46MIbQeeT1mhA+5PV/inyDdQipf8LTvMXbwvoDy7IruDNVZKTfV4CTSRUYdybUCnGU7KUTDxLgCknqUm5aAW6/1p6eMsOYsphLzsHrE0Y/P5bQedx1F/4yPHnMB3/IOoTU9+BL8PhtjuFKBpZXnYNJxTuv+2XqolKR2UQgHhS5novuxVySJhBNRF3SoKK1XZbbXjVwWNyOjlqWJjrWJIy+P5bQedyldNScP+HZ61xKSK3jyrz+NiHG1hcOLL/+P+PDF2gOkekKGiNWKgJ+8Z/x8Iv4DdQHzcpZyF4v19I27w9/yPGDFQvmEpKtqv/TLiWMfn4sofMm9eAH8Ao0zzh7h4sJqYtxZd5/D7hkYPneDzl5idlzNHcIB0jVlQ+8ULzw/nc5/ojzl2juE0apD7LRnJxe04dMz2iOCFNtGFpTuXA5AhcTRo8mdN4kz30nVjEC4YTZQy4gpC7GlTlrePKhGsKKgeXpCYeO0MAd/GH7yKQUlXPLOasOH3FnSphjHuDvEu4gB8g66oNbtr6eMbFIA4fIBJkgayoXriw2XEDQPJrQeROAlY6aeYOcMf+IVYTU3XFlZufMHinGywaW3YLpObVBAsbjF4QJMsVUSayjk4voPsHJOQfPWDhCgDnmDl6XIRerD24HsGtw86RMHOLvVSHrKBdeVE26gKB5NKHzaIwLOmrqBWJYZDLhASG16c0Tn+CdRhWDgWXnqRZUTnPIHuMJTfLVpkoYy5CzylHVTGZMTwkGAo2HBlkQplrJX6U+uF1wZz2uwS1SQ12IqWaPuO4baZaEFBdukksJmkcTOm+YJSvoqPFzxFA/YUhIvWxcmSdPWTWwbAKVp6rxTtPFUZfKIwpzm4IoMfaYQLWgmlG5FME2gdBgm+J7J+rtS/XBbaVLsR7bpPQnpMFlo2doWaVceHk9+MkyguZNCJ1He+kuHTWyQAzNM5YSUg/GlTk9ZunAsg1qELVOhUSAK0LABIJHLKbqaEbHZLL1VA3VgqoiOKXYiS+HRyaEKgsfIqX64HYWbLRXy/qWoylIV9gudL1OWBNgBgTNmxA6b4txDT4gi3Ri7xFSLxtXpmmYnzAcWDZgY8d503LFogz5sbonDgkKcxGsWsE1OI+rcQtlgBBCSOKD1mtqYpIU8cTvBmAT0yZe+zUzeY92fYjTtGipXLhuR0ePoHk0ofNWBX+lo8Z7pAZDk8mEw5L7dVyZZoE/pTewbI6SNbiAL5xeygW4xPRuLCGbhcO4RIeTMFYHEJkYyEO9HmJfXMDEj/LaH781wHHZEtqSQ/69UnGpzH7LKIAZEDSPJnTesJTUa+rwTepI9dLJEawYV+ZkRn9g+QirD8vF8Mq0jFQ29js6kCS3E1+jZIhgPNanHdHFqFvPJLHqFwQqbIA4jhDxcNsOCCQLDomaL/dr5lyJaJU6FxPFjO3JOh3kVMcROo8u+C+jo05GjMF3P3/FuDLn5x2M04xXULPwaS6hBYki+MrMdZJSgPHlcB7nCR5bJ9Kr5ACUn9jk5kivdd8tk95SOGrtqu9lr2IhK65ZtEl7ZKrp7DrqwZfRUSN1el7+7NJxZbywOC8neNKTch5vsTEMNsoCCqHBCqIPRjIPkm0BjvFODGtto99rCl+d3wmHkW0FPdpZtC7MMcVtGFQjJLX5bdQ2+x9ypdc313uj8xlsrfuLgWXz1cRhZvJYX0iNVBRcVcmCXZs6aEf3RQF2WI/TcCbKmGU3IOoDJGDdDub0+hYckt6PlGu2BcxmhbTdj/klhccLGJMcqRjMJP1jW2ETqLSWJ/29MAoORluJ+6LPffBZbi5gqi5h6catQpmOT7/OFf5UorRpLzCqcMltBLhwd1are3kztrSzXO0LUbXRQcdLh/RdSZ+swRm819REDrtqzC4es6Gw4JCKlSnjYVpo0xeq33PrADbFLL3RuCmObVmPN+24kfa+AojDuM4umKe2QwCf6EN906HwjujaitDs5o0s1y+k3lgbT2W2i7FJdnwbLXhJUBq/9liTctSmFC/0OqUinb0QddTWamtjbHRFuWJJ6NpqZ8vO3fZJ37Db+2GkaPYLGHs7XTTdiFQJ68SkVJFVmY6McR5UycflNCsccHFaV9FNbR4NttLxw4pQ7wJd066Z0ohVbzihaxHVExd/ay04oxUKWt+AsdiQ9OUyZ2krzN19IZIwafSTFgIBnMV73ADj7V/K8u1MaY2sJp2HWm0f41tqwajEvdHWOJs510MaAqN4aoSiPCXtN2KSi46dUxHdaMquar82O1x5jqhDGvqmoE9LfxcY3zqA7/x3HA67r9ZG4O6Cuxu12/+TP+eLP+I+HErqDDCDVmBDO4larujNe7x8om2rMug0MX0rL1+IWwdwfR+p1TNTyNmVJ85ljWzbWuGv8/C7HD/izjkHNZNYlhZcUOKVzKFUxsxxN/kax+8zPWPSFKw80rJr9Tizyj3o1gEsdwgWGoxPezDdZ1TSENE1dLdNvuKL+I84nxKesZgxXVA1VA1OcL49dFlpFV5yJMhzyCmNQ+a4BqusPJ2bB+xo8V9u3x48VVIEPS/mc3DvAbXyoYr6VgDfh5do5hhHOCXMqBZUPhWYbWZECwVJljLgMUWOCB4MUuMaxGNUQDVI50TQ+S3kFgIcu2qKkNSHVoM0SHsgoZxP2d5HH8B9woOk4x5bPkKtAHucZsdykjxuIpbUrSILgrT8G7G5oCW+K0990o7E3T6AdW4TilH5kDjds+H64kS0mz24grtwlzDHBJqI8YJQExotPvoC4JBq0lEjjQkyBZ8oH2LnRsQ4Hu1QsgDTJbO8fQDnllitkxuVskoiKbRF9VwzMDvxHAdwB7mD9yCplhHFEyUWHx3WtwCbSMMTCUCcEmSGlg4gTXkHpZXWQ7kpznK3EmCHiXInqndkQjunG5kxTKEeGye7jWz9cyMR2mGiFQ15ENRBTbCp+Gh86vAyASdgmJq2MC6hoADQ3GosP0QHbnMHjyBQvQqfhy/BUbeHd5WY/G/9LK/8Ka8Jd7UFeNWEZvzPb458Dn8DGLOe3/wGL/4xP+HXlRt+M1PE2iLhR8t+lfgxsuh7AfO2AOf+owWhSZRYQbd622hbpKWKuU+XuvNzP0OseRDa+mObgDHJUSc/pKx31QdKffQ5OIJpt8GWjlgTwMc/w5MPCR/yl1XC2a2Yut54SvOtMev55Of45BOat9aWG27p2ZVORRvnEk1hqWMVUmqa7S2YtvlIpspuF1pt0syuZS2NV14mUidCSfzQzg+KqvIYCMljIx2YK2AO34fX4GWdu5xcIAb8MzTw+j/lyWM+Dw/gjs4GD6ehNgA48kX/AI7XXM/XAN4WHr+9ntywqoCakCqmKP0rmQrJJEErG2Upg1JObr01lKQy4jskWalKYfJ/EDLMpjNSHFEUAde2fltaDgmrNaWQ9+AAb8I5vKjz3L1n1LriB/BXkG/wwR9y/oRX4LlioHA4LzP2inzRx/DWmutRweFjeP3tNeSGlaE1Fde0OS11yOpmbIp2u/jF1n2RRZviJM0yBT3IZl2HWImKjQOxIyeU325b/qWyU9Moj1o07tS0G7qJDoGHg5m8yeCxMoEH8GU45tnrNM84D2l297DQ9t1YP7jki/7RmutRweEA77/HWXOh3HCxkRgldDQkAjNTMl2Iloc1qN5JfJeeTlyTRzxURTdn1Ixv2uKjs12AbdEWlBtmVdk2k7FFwj07PCZ9XAwW3dG+8xKzNFr4EnwBZpy9Qzhh3jDXebBpYcpuo4fQ44u+fD1dweEnHzI7v0xuuOALRUV8rXpFyfSTQYkhd7IHm07jpyhlkCmI0ALYqPTpUxXS+z4jgDj1Pflvmz5ecuItpIBxyTHpSTGWd9g1ApfD/bvwUhL4nT1EzqgX7cxfCcNmb3mPL/qi9SwTHJ49oj5ZLjccbTG3pRmlYi6JCG0mQrAt1+i2UXTZ2dv9IlQpN5naMYtviaXlTrFpoMsl3bOAFEa8sqPj2WCMrx3Yjx99qFwO59Aw/wgx+HlqNz8oZvA3exRDvuhL1jMQHPaOJ0+XyA3fp1OfM3qObEVdhxjvynxNMXQV4+GJyvOEFqeQBaIbbO7i63rpxCltdZShPFxkjM2FPVkn3TG+Rp9pO3l2RzFegGfxGDHIAh8SteR0C4HopXzRF61nheDw6TFN05Ebvq8M3VKKpGjjO6r7nhudTEGMtYM92HTDaR1FDMXJ1eThsbKfywyoWwrzRSXkc51flG3vIid62h29bIcFbTGhfV+faaB+ohj7dPN0C2e2lC96+XouFByen9AsunLDJZ9z7NExiUc0OuoYW6UZkIyx2YUR2z6/TiRjyKMx5GbbjLHvHuf7YmtKghf34LJfx63Yg8vrvN2zC7lY0x0tvKezo4HmGYDU+Gab6dFL+KI761lDcNifcjLrrr9LWZJctG1FfU1uwhoQE22ObjdfkSzY63CbU5hzs21WeTddH2BaL11Gi7lVdlxP1nkxqhnKhVY6knS3EPgVGg1JpN5cP/hivujOelhXcPj8HC/LyI6MkteVjlolBdMmF3a3DbsuAYhL44dxzthWSN065xxUd55Lmf0wRbOYOqH09/o9WbO2VtFdaMb4qBgtFJoT1SqoN8wPXMoXLb3p1PUEhxfnnLzGzBI0Ku7FxrKsNJj/8bn/H8fPIVOd3rfrklUB/DOeO+nkghgSPzrlPxluCMtOnDL4Yml6dK1r3vsgMxgtPOrMFUZbEUbTdIzii5beq72G4PD0DKnwjmBULUVFmy8t+k7fZ3pKc0Q4UC6jpVRqS9Umv8bxw35flZVOU1X7qkjnhZlsMbk24qQ6Hz7QcuL6sDC0iHHki96Uh2UdvmgZnjIvExy2TeJdMDZNSbdZyAHe/Yd1xsQhHiKzjh7GxQ4yqMPaywPkjMamvqrYpmO7Knad+ZQC5msCuAPWUoxrxVhrGv7a+KLXFhyONdTMrZ7ke23qiO40ZJUyzgYyX5XyL0mV7NiUzEs9mjtbMN0dERqwyAJpigad0B3/zRV7s4PIfXSu6YV/MK7+OrYe/JvfGMn/PHJe2fyUdtnFrKRNpXV0Y2559aWPt/G4BlvjTMtXlVIWCnNyA3YQBDmYIodFz41PvXPSa6rq9lWZawZ4dP115HXV/M/tnFkkrBOdzg6aP4pID+MZnTJ1SuuB6iZlyiox4HT2y3YBtkUKWooacBQUDTpjwaDt5poBHl1/HXltwP887lKKXxNUEyPqpGTyA699UqY/lt9yGdlUKra0fFWS+36iylVWrAyd7Uw0CZM0z7xKTOduznLIjG2Hx8cDPLb+OvK6Bv7n1DYci4CxUuRxrjBc0bb4vD3rN5Zz36ntLb83eVJIB8LiIzCmn6SMPjlX+yNlTjvIGjs+QzHPf60Aj62/jrzG8j9vYMFtm1VoRWCJdmw7z9N0t+c8cxZpPeK4aTRicS25QhrVtUp7U578chk4q04Wx4YoQSjFryUlpcQ1AbxZ/XVMknIU//OGl7Q6z9Zpxi0+3yFhSkjUDpnCIUhLWVX23KQ+L9vKvFKI0ZWFQgkDLvBoylrHNVmaw10zwCPrr5tlodfnf94EWnQ0lFRWy8pW9LbkLsyUVDc2NSTHGDtnD1uMtchjbCeb1mpxFP0YbcClhzdLu6lfO8Bj6q+bdT2sz/+8SZCV7VIxtt0DUn9L7r4cLYWDSXnseEpOGFuty0qbOVlS7NNzs5FOGJUqQpl2Q64/yBpZf90sxbE+//PGdZ02HSipCbmD6NItmQ4Lk5XUrGpDMkhbMm2ZVheNYV+VbUWTcv99+2NyX1VoafSuC+AN6q9bFIMv5X/eagNWXZxEa9JjlMwNWb00akGUkSoepp1/yRuuqHGbUn3UdBSTxBU6SEVklzWRUkPndVvw2PrrpjvxOvzPmwHc0hpmq82npi7GRro8dXp0KXnUQmhZbRL7NEVp1uuZmO45vuzKsHrktS3GLWXODVjw+vXXLYx4Hf7njRPd0i3aoAGX6W29GnaV5YdyDj9TFkakje7GHYzDoObfddHtOSpoi2SmzJHrB3hM/XUDDEbxP2/oosszcRlehWXUvzHv4TpBVktHqwenFo8uLVmy4DKLa5d3RtLrmrM3aMFr1183E4sewf+85VWeg1c5ag276NZrM9IJVNcmLEvDNaV62aq+14IAOGFsBt973Ra8Xv11YzXwNfmft7Jg2oS+XOyoC8/cwzi66Dhmgk38kUmP1CUiYWOX1bpD2zWXt2FCp7uq8703APAa9dfNdscR/M/bZLIyouVxqJfeWvG9Je+JVckHQ9+CI9NWxz+blX/KYYvO5n2tAP/vrlZ7+8/h9y+9qeB/Hnt967e5mevX10rALDWK//FaAT5MXdBXdP0C/BAes792c40H+AiAp1e1oH8HgH94g/Lttx1gp63op1eyoM/Bvw5/G/7xFbqJPcCXnmBiwDPb/YKO4FX4OjyCb289db2/Noqicw4i7N6TVtoz8tNwDH+8x/i6Ae7lmaQVENzJFb3Di/BFeAwz+Is9SjeQySpPqbLFlNmyz47z5a/AF+AYFvDmHqibSXTEzoT4Gc3OALaqAP4KPFUJ6n+1x+rGAM6Zd78bgJ0a8QN4GU614vxwD9e1Amy6CcskNrczLx1JIp6HE5UZD/DBHrFr2oNlgG4Odv226BodoryjGJ9q2T/AR3vQrsOCS0ctXZi3ruLlhpFDJYl4HmYtjQCP9rhdn4suySLKDt6wLcC52h8xPlcjju1fn+yhuw4LZsAGUuo2b4Fx2UwQu77uqRHXGtg92aN3tQCbFexc0uk93vhTXbct6y7MulLycoUljx8ngDMBg1tvJjAazpEmOtxlzclvj1vQf1Tx7QlPDpGpqgtdSKz/d9/hdy1vTfFHSmC9dGDZbLiezz7Ac801HirGZsWjydfZyPvHXL/Y8Mjzg8BxTZiuwKz4Eb8sBE9zznszmjvFwHKPIWUnwhqfVRcd4Ck0K6ate48m1oOfrX3/yOtvAsJ8zsPAM89sjnddmuLuDPjX9Bu/L7x7xpMzFk6nWtyQfPg278Gn4Aekz2ZgOmU9eJ37R14vwE/BL8G3aibCiWMWWDQ0ZtkPMnlcGeAu/Ag+8ZyecU5BPuy2ILD+sQqyZhAKmn7XZd+jIMTN9eBL7x95xVLSX4On8EcNlXDqmBlqS13jG4LpmGbkF/0CnOi3H8ETOIXzmnmtb0a16Tzxj1sUvQCBiXZGDtmB3KAefPH94xcUa/6vwRn80GOFyjEXFpba4A1e8KQfFF+259tx5XS4egYn8fQsLGrqGrHbztr+uByTahWuL1NUGbDpsnrwBfePPwHHIf9X4RnM4Z2ABWdxUBlqQ2PwhuDxoS0vvqB1JzS0P4h2nA/QgTrsJFn+Y3AOjs9JFC07CGWX1oNX3T/yHOzgDjwPn1PM3g9Jk9lZrMEpxnlPmBbjyo2+KFXRU52TJM/2ALcY57RUzjObbjqxVw++4P6RAOf58pcVsw9Daje3htriYrpDOonre3CudSe6bfkTEgHBHuDiyu5MCsc7BHhYDx7ePxLjqigXZsw+ijMHFhuwBmtoTPtOxOrTvYJDnC75dnUbhfwu/ZW9AgYd+peL68HD+0emKquiXHhWjJg/UrkJYzuiaL3E9aI/ytrCvAd4GcYZMCkSQxfUg3v3j8c4e90j5ZTPdvmJJGHnOCI2nHS8081X013pHuBlV1gB2MX1YNmWLHqqGN/TWmG0y6clJWthxNUl48q38Bi8vtMKyzzpFdSDhxZ5WBA5ZLt8Jv3895DduBlgbPYAj8C4B8hO68FDkoh5lydC4FiWvBOVqjYdqjiLv92t8yPDjrDaiHdUD15qkSURSGmXJwOMSxWAXYwr3zaAufJ66l+94vv3AO+vPcD7aw/w/toDvL/2AO+vPcD7aw/wHuD9tQd4f+0B3l97gPfXHuD9tQd4f+0B3l97gG8LwP8G/AL8O/A5OCq0Ys2KIdv/qOIXG/4mvFAMF16gZD+2Xvu/B8as5+8bfllWyg0zaNO5bfXj6vfhhwD86/Aq3NfRS9t9WPnhfnvCIw/CT8GLcFTMnpntdF/z9V+PWc/vWoIH+FL3Znv57PitcdGP4R/C34avw5fgRVUInCwbsn1yyA8C8zm/BH8NXoXnVE6wVPjdeCI38kX/3+Ct9dbz1pTmHFRu+Hm4O9Ch3clr99negxfwj+ER/DR8EV6B5+DuQOnTgUw5rnkY+FbNU3gNXh0o/JYTuWOvyBf9FvzX663HH/HejO8LwAl8Hl5YLTd8q7sqA3wbjuExfAFegQdwfyDoSkWY8swzEf6o4Qyewefg+cHNbqMQruSL/u/WWc+E5g7vnnEXgDmcDeSGb/F4cBcCgT+GGRzDU3hZYburAt9TEtHgbM6JoxJ+6NMzzTcf6c2bycv2+KK/f+l6LBzw5IwfqZJhA3M472pWT/ajKxnjv4AFnMEpnBTPND6s2J7qHbPAqcMK74T2mZ4VGB9uJA465It+/eL1WKhYOD7xHOkr1ajK7d0C4+ke4Hy9qXZwpgLr+Znm/uNFw8xQOSy8H9IzjUrd9+BIfenYaylf9FsXr8fBAadnPIEDna8IBcwlxnuA0/Wv6GAWPd7dDIKjMdSWueAsBj4M7TOd06qBbwDwKr7oleuxMOEcTuEZTHWvDYUO7aHqAe0Bbq+HEFRzOz7WVoTDQkVds7A4sIIxfCQdCefFRoIOF/NFL1mPab/nvOakSL/Q1aFtNpUb/nFOVX6gzyg/1nISyDfUhsokIzaBR9Kxm80s5mK+6P56il1jXic7nhQxsxSm3OwBHl4fFdLqi64nDQZvqE2at7cWAp/IVvrN6/BFL1mPhYrGMBfOi4PyjuSGf6wBBh7p/FZTghCNWGgMzlBbrNJoPJX2mW5mwZfyRffXo7OFi5pZcS4qZUrlViptrXtw+GQoyhDPS+ANjcGBNRiLCQDPZPMHuiZfdFpPSTcQwwKYdRNqpkjm7AFeeT0pJzALgo7g8YYGrMHS0iocy+YTm2vyRUvvpXCIpQ5pe666TJrcygnScUf/p0NDs/iAI/nqDHC8TmQT8x3NF91l76oDdQGwu61Z6E0ABv7uO1dbf/37Zlv+Zw/Pbh8f1s4Avur6657/+YYBvur6657/+YYBvur6657/+YYBvur6657/+aYBvuL6657/+VMA8FXWX/f8zzcN8BXXX/f8zzcNMFdbf93zP38KLPiK6697/uebtuArrr/u+Z9vGmCusP6653/+1FjwVdZf9/zPN7oHX339dc//fNMu+irrr3v+50+Bi+Zq6697/uebA/jz8Pudf9ht/fWv517J/XUzAP8C/BAeX9WCDrUpZ3/dEMBxgPcfbtTVvsYV5Yn32u03B3Ac4P3b8I+vxNBKeeL9dRMAlwO83959qGO78sT769oB7g3w/vGVYFzKE++v6wV4OMD7F7tckFkmT7y/rhHgpQO8b+4Y46XyxPvrugBeNcB7BRiX8sT767oAvmCA9woAHsoT76+rBJjLBnh3txOvkifeX1dswZcO8G6N7sXyxPvr6i340gHe3TnqVfLE++uKAb50gHcXLnrX8sR7gNdPRqwzwLu7Y/FO5Yn3AK9jXCMGeHdgxDuVJ75VAI8ljP7PAb3/RfjcZfePHBB+79dpfpH1CanN30d+mT1h9GqAxxJGM5LQeeQ1+Tb+EQJrElLb38VHQ94TRq900aMIo8cSOo+8Dp8QfsB8zpqE1NO3OI9Zrj1h9EV78PqE0WMJnUdeU6E+Jjyk/hbrEFIfeWbvId8H9oTRFwdZaxJGvziW0Hn0gqYB/wyZ0PwRlxJST+BOw9m77Amj14ii1yGM/txYQudN0qDzGe4EqfA/5GJCagsHcPaEPWH0esekSwmjRxM6b5JEcZ4ww50ilvAOFxBSx4yLW+A/YU8YvfY5+ALC6NGEzhtmyZoFZoarwBLeZxUhtY4rc3bKnjB6TKJjFUHzJoTOozF2YBpsjcyxDgzhQ1YRUse8+J4wenwmaylB82hC5w0zoRXUNXaRBmSMQUqiWSWkLsaVqc/ZE0aPTFUuJWgeTei8SfLZQeMxNaZSIzbII4aE1Nmr13P2hNHjc9E9guYNCZ032YlNwESMLcZiLQHkE4aE1BFg0yAR4z1h9AiAGRA0jyZ03tyIxWMajMPWBIsxYJCnlITU5ShiHYdZ94TR4wCmSxg9jtB5KyPGYzymAYexWEMwAPIsAdYdV6aObmNPGD0aYLoEzaMJnTc0Ygs+YDw0GAtqxBjkuP38bMRWCHn73xNGjz75P73WenCEJnhwyVe3AEe8TtKdJcYhBl97wuhNAObK66lvD/9J9NS75v17wuitAN5fe4D31x7g/bUHeH/tAd5fe4D3AO+vPcD7aw/w/toDvL/2AO+vPcD7aw/w/toDvAd4f/24ABzZ8o+KLsSLS+Pv/TqTb3P4hKlQrTGh+fbIBT0Axqznnb+L/V2mb3HkN5Mb/nEHeK7d4IcDld6lmDW/iH9E+AH1MdOw/Jlu2T1xNmY98sv4wHnD7D3uNHu54WUuOsBTbQuvBsPT/UfzNxGYzwkP8c+Yz3C+r/i6DcyRL/rZ+utRwWH5PmfvcvYEt9jLDS/bg0/B64DWKrQM8AL8FPwS9beQCe6EMKNZYJol37jBMy35otdaz0Bw2H/C2Smc7+WGB0HWDELBmOByA3r5QONo4V+DpzR/hFS4U8wMW1PXNB4TOqYz9urxRV++ntWCw/U59Ty9ebdWbrgfRS9AYKKN63ZokZVygr8GZ/gfIhZXIXPsAlNjPOLBby5c1eOLvmQ9lwkOy5x6QV1j5TYqpS05JtUgUHUp5toHGsVfn4NX4RnMCe+AxTpwmApTYxqMxwfCeJGjpXzRF61nbcHhUBPqWze9svwcHJ+S6NPscKrEjug78Dx8Lj3T8D4YxGIdxmJcwhi34fzZUr7olevZCw5vkOhoClq5zBPZAnygD/Tl9EzDh6kl3VhsHYcDEb+hCtJSvuiV69kLDm+WycrOTArHmB5/VYyP6jOVjwgGawk2zQOaTcc1L+aLXrKeveDwZqlKrw8U9Y1p66uK8dEzdYwBeUQAY7DbyYNezBfdWQ97weEtAKYQg2xJIkuveAT3dYeLGH+ShrWNwZgN0b2YL7qznr3g8JYAo5bQBziPjx7BPZ0d9RCQp4UZbnFdzBddor4XHN4KYMrB2qHFRIzzcLAHQZ5the5ovui94PCWAPefaYnxIdzRwdHCbuR4B+tbiy96Lzi8E4D7z7S0mEPd+eqO3cT53Z0Y8SV80XvB4Z0ADJi/f7X113f+7p7/+UYBvur6657/+YYBvur6657/+aYBvuL6657/+aYBvuL6657/+aYBvuL6657/+aYBvuL6657/+VMA8FXWX/f8z58OgK+y/rrnf75RgLna+uue//lTA/CV1V/3/M837aKvvv6653++UQvmauuve/7nTwfAV1N/3fM/fzr24Cuuv+75nz8FFnxl9dc9//MOr/8/glixwRuUfM4AAAAASUVORK5CYII=";
+    }
+    getSearchTexture() {
+      return "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEIAAAAhCAAAAABIXyLAAAAAOElEQVRIx2NgGAWjYBSMglEwEICREYRgFBZBqDCSLA2MGPUIVQETE9iNUAqLR5gIeoQKRgwXjwAAGn4AtaFeYLEAAAAASUVORK5CYII=";
+    }
+    dispose() {
+      this.edgesRT.dispose();
+      this.weightsRT.dispose();
+      this.areaTexture.dispose();
+      this.searchTexture.dispose();
+      this.materialEdges.dispose();
+      this.materialWeights.dispose();
+      this.materialBlend.dispose();
+      this.fsQuad.dispose();
+    }
+  };
+
+  // node_modules/three/examples/jsm/shaders/OutputShader.js
+  var OutputShader = {
+    name: "OutputShader",
+    uniforms: {
+      "tDiffuse": { value: null },
+      "toneMappingExposure": { value: 1 }
+    },
+    vertexShader: (
+      /* glsl */
+      `
+		precision highp float;
+
+		uniform mat4 modelViewMatrix;
+		uniform mat4 projectionMatrix;
+
+		attribute vec3 position;
+		attribute vec2 uv;
+
+		varying vec2 vUv;
+
+		void main() {
+
+			vUv = uv;
+			gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+		}`
+    ),
+    fragmentShader: (
+      /* glsl */
+      `
+	
+		precision highp float;
+
+		uniform sampler2D tDiffuse;
+
+		#include <tonemapping_pars_fragment>
+		#include <colorspace_pars_fragment>
+
+		varying vec2 vUv;
+
+		void main() {
+
+			gl_FragColor = texture2D( tDiffuse, vUv );
+
+			// tone mapping
+
+			#ifdef LINEAR_TONE_MAPPING
+
+				gl_FragColor.rgb = LinearToneMapping( gl_FragColor.rgb );
+
+			#elif defined( REINHARD_TONE_MAPPING )
+
+				gl_FragColor.rgb = ReinhardToneMapping( gl_FragColor.rgb );
+
+			#elif defined( CINEON_TONE_MAPPING )
+
+				gl_FragColor.rgb = CineonToneMapping( gl_FragColor.rgb );
+
+			#elif defined( ACES_FILMIC_TONE_MAPPING )
+
+				gl_FragColor.rgb = ACESFilmicToneMapping( gl_FragColor.rgb );
+
+			#elif defined( AGX_TONE_MAPPING )
+
+				gl_FragColor.rgb = AgXToneMapping( gl_FragColor.rgb );
+
+			#elif defined( NEUTRAL_TONE_MAPPING )
+
+				gl_FragColor.rgb = NeutralToneMapping( gl_FragColor.rgb );
+
+			#endif
+
+			// color space
+
+			#ifdef SRGB_TRANSFER
+
+				gl_FragColor = sRGBTransferOETF( gl_FragColor );
+
+			#endif
+
+		}`
+    )
+  };
+
+  // node_modules/three/examples/jsm/postprocessing/OutputPass.js
+  var OutputPass = class extends Pass {
+    constructor() {
+      super();
+      const shader = OutputShader;
+      this.uniforms = UniformsUtils.clone(shader.uniforms);
+      this.material = new RawShaderMaterial({
+        name: shader.name,
+        uniforms: this.uniforms,
+        vertexShader: shader.vertexShader,
+        fragmentShader: shader.fragmentShader
+      });
+      this.fsQuad = new FullScreenQuad(this.material);
+      this._outputColorSpace = null;
+      this._toneMapping = null;
+    }
+    render(renderer2, writeBuffer, readBuffer) {
+      this.uniforms["tDiffuse"].value = readBuffer.texture;
+      this.uniforms["toneMappingExposure"].value = renderer2.toneMappingExposure;
+      if (this._outputColorSpace !== renderer2.outputColorSpace || this._toneMapping !== renderer2.toneMapping) {
+        this._outputColorSpace = renderer2.outputColorSpace;
+        this._toneMapping = renderer2.toneMapping;
+        this.material.defines = {};
+        if (ColorManagement.getTransfer(this._outputColorSpace) === SRGBTransfer) this.material.defines.SRGB_TRANSFER = "";
+        if (this._toneMapping === LinearToneMapping) this.material.defines.LINEAR_TONE_MAPPING = "";
+        else if (this._toneMapping === ReinhardToneMapping) this.material.defines.REINHARD_TONE_MAPPING = "";
+        else if (this._toneMapping === CineonToneMapping) this.material.defines.CINEON_TONE_MAPPING = "";
+        else if (this._toneMapping === ACESFilmicToneMapping) this.material.defines.ACES_FILMIC_TONE_MAPPING = "";
+        else if (this._toneMapping === AgXToneMapping) this.material.defines.AGX_TONE_MAPPING = "";
+        else if (this._toneMapping === NeutralToneMapping) this.material.defines.NEUTRAL_TONE_MAPPING = "";
+        this.material.needsUpdate = true;
+      }
+      if (this.renderToScreen === true) {
+        renderer2.setRenderTarget(null);
+        this.fsQuad.render(renderer2);
+      } else {
+        renderer2.setRenderTarget(writeBuffer);
+        if (this.clear) renderer2.clear(renderer2.autoClearColor, renderer2.autoClearDepth, renderer2.autoClearStencil);
+        this.fsQuad.render(renderer2);
+      }
+    }
+    dispose() {
+      this.material.dispose();
+      this.fsQuad.dispose();
+    }
+  };
+
   // chess3d-renderer.js
   var PIECE_SCALE = 0.5;
+  var SS = 1.5;
+  var SS_CAP = 2.5;
+  var BLOOM_STRENGTH = 0.25;
+  var BLOOM_RADIUS = 0.4;
+  var BLOOM_THRESHOLD = 0.85;
+  var composer;
+  var bloomPass;
+  var smaaPass;
+  var usePost = false;
   var HIDDEN_NODES = /* @__PURE__ */ new Set(["king", "queen", "rook", "bishop", "knight", "pawn", "plane"]);
   var PIECE_NAMES = /* @__PURE__ */ new Set(["king", "queen", "rook", "bishop", "knight", "pawn"]);
   var KIND_NAMES = ["king", "queen", "rook", "bishop", "knight", "pawn"];
@@ -24487,7 +25896,7 @@ void main() {
       try {
         piecePool.length = 0;
         renderer = new WebGLRenderer({ canvas, antialias: true, alpha: false });
-        renderer.setPixelRatio(window.devicePixelRatio || 1);
+        renderer.setPixelRatio(Math.min((window.devicePixelRatio || 1) * SS, SS_CAP));
         renderer.shadowMap.enabled = false;
         renderer.toneMapping = ACESFilmicToneMapping;
         renderer.toneMappingExposure = 1;
@@ -24496,6 +25905,28 @@ void main() {
         camera = new PerspectiveCamera(45, canvas.width / canvas.height, 0.05, 200);
         await loadEnvironment();
         await loadGlb();
+        try {
+          const size = renderer.getDrawingBufferSize(new Vector2());
+          const rt = new WebGLRenderTarget(size.x, size.y, {
+            type: HalfFloatType,
+            samples: 4
+            // MSAA-resolved HDR input = crisp silhouettes
+          });
+          composer = new EffectComposer(renderer, rt);
+          composer.addPass(new RenderPass(scene, camera));
+          bloomPass = new UnrealBloomPass(new Vector2(size.x, size.y), BLOOM_STRENGTH, BLOOM_RADIUS, BLOOM_THRESHOLD);
+          composer.addPass(bloomPass);
+          smaaPass = new SMAAPass(size.x, size.y);
+          composer.addPass(smaaPass);
+          composer.addPass(new OutputPass());
+          usePost = true;
+        } catch (e) {
+          console.warn("[chess3d] EffectComposer init failed; falling back to bare render", e);
+          composer = null;
+          bloomPass = null;
+          smaaPass = null;
+          usePost = false;
+        }
         animate();
         return true;
       } catch (e) {
@@ -24563,11 +25994,25 @@ void main() {
     },
     resize(w, h) {
       if (!renderer) return;
+      renderer.setPixelRatio(Math.min((window.devicePixelRatio || 1) * SS, SS_CAP));
       renderer.setSize(w, h, false);
       camera.aspect = w / h;
       camera.updateProjectionMatrix();
+      if (composer || bloomPass || smaaPass) {
+        const s = renderer.getDrawingBufferSize(new Vector2());
+        if (composer) composer.setSize(s.x, s.y);
+        if (bloomPass) bloomPass.setSize(s.x, s.y);
+        if (smaaPass) smaaPass.setSize(s.x, s.y);
+      }
     },
     dispose() {
+      if (composer) {
+        composer.dispose();
+        composer = null;
+      }
+      bloomPass = null;
+      smaaPass = null;
+      usePost = false;
       if (renderer) {
         renderer.dispose();
         renderer = null;
@@ -24630,6 +26075,8 @@ void main() {
   }
   function animate() {
     requestAnimationFrame(animate);
-    if (renderer && scene && camera) renderer.render(scene, camera);
+    if (!renderer || !scene || !camera) return;
+    if (usePost && composer) composer.render();
+    else renderer.render(scene, camera);
   }
 })();

--- a/iosApp/iosApp/Resources/chess3d-bundle.js
+++ b/iosApp/iosApp/Resources/chess3d-bundle.js
@@ -1,5 +1,5 @@
 (() => {
-  // node_modules/three/build/three.module.js
+  // tools/chess3d-renderer/node_modules/three/build/three.module.js
   /**
    * @license
    * Copyright 2010-2024 Three.js Authors
@@ -21628,7 +21628,7 @@ void main() {
     }
   }
 
-  // node_modules/three/examples/jsm/utils/BufferGeometryUtils.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/utils/BufferGeometryUtils.js
   function toTrianglesDrawMode(geometry, drawMode) {
     if (drawMode === TrianglesDrawMode) {
       console.warn("THREE.BufferGeometryUtils.toTrianglesDrawMode(): Geometry already defined as triangles.");
@@ -21684,7 +21684,7 @@ void main() {
     }
   }
 
-  // node_modules/three/examples/jsm/loaders/GLTFLoader.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/loaders/GLTFLoader.js
   var GLTFLoader = class extends Loader {
     constructor(manager) {
       super(manager);
@@ -24166,7 +24166,7 @@ void main() {
     });
   }
 
-  // node_modules/three/examples/jsm/loaders/RGBELoader.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/loaders/RGBELoader.js
   var RGBELoader = class extends DataTextureLoader {
     constructor(manager) {
       super(manager);
@@ -24407,7 +24407,7 @@ void main() {
     }
   };
 
-  // node_modules/three/examples/jsm/environments/RoomEnvironment.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/environments/RoomEnvironment.js
   var RoomEnvironment = class extends Scene {
     constructor() {
       super();
@@ -24496,7 +24496,7 @@ void main() {
     return material;
   }
 
-  // node_modules/three/examples/jsm/shaders/CopyShader.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/shaders/CopyShader.js
   var CopyShader = {
     name: "CopyShader",
     uniforms: {
@@ -24536,7 +24536,7 @@ void main() {
     )
   };
 
-  // node_modules/three/examples/jsm/postprocessing/Pass.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/postprocessing/Pass.js
   var Pass = class {
     constructor() {
       this.isPass = true;
@@ -24580,7 +24580,7 @@ void main() {
     }
   };
 
-  // node_modules/three/examples/jsm/postprocessing/ShaderPass.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/postprocessing/ShaderPass.js
   var ShaderPass = class extends Pass {
     constructor(shader, textureID) {
       super();
@@ -24620,7 +24620,7 @@ void main() {
     }
   };
 
-  // node_modules/three/examples/jsm/postprocessing/MaskPass.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/postprocessing/MaskPass.js
   var MaskPass = class extends Pass {
     constructor(scene2, camera2) {
       super();
@@ -24677,7 +24677,7 @@ void main() {
     }
   };
 
-  // node_modules/three/examples/jsm/postprocessing/EffectComposer.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/postprocessing/EffectComposer.js
   var EffectComposer = class {
     constructor(renderer2, renderTarget) {
       this.renderer = renderer2;
@@ -24799,7 +24799,7 @@ void main() {
     }
   };
 
-  // node_modules/three/examples/jsm/postprocessing/RenderPass.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/postprocessing/RenderPass.js
   var RenderPass = class extends Pass {
     constructor(scene2, camera2, overrideMaterial = null, clearColor = null, clearAlpha = null) {
       super();
@@ -24850,7 +24850,7 @@ void main() {
     }
   };
 
-  // node_modules/three/examples/jsm/shaders/LuminosityHighPassShader.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/shaders/LuminosityHighPassShader.js
   var LuminosityHighPassShader = {
     name: "LuminosityHighPassShader",
     shaderID: "luminosityHighPass",
@@ -24903,7 +24903,7 @@ void main() {
     )
   };
 
-  // node_modules/three/examples/jsm/postprocessing/UnrealBloomPass.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/postprocessing/UnrealBloomPass.js
   var UnrealBloomPass = class _UnrealBloomPass extends Pass {
     constructor(resolution, strength, radius, threshold) {
       super();
@@ -25159,7 +25159,7 @@ void main() {
   UnrealBloomPass.BlurDirectionX = new Vector2(1, 0);
   UnrealBloomPass.BlurDirectionY = new Vector2(0, 1);
 
-  // node_modules/three/examples/jsm/shaders/SMAAShader.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/shaders/SMAAShader.js
   var SMAAEdgesShader = {
     name: "SMAAEdgesShader",
     defines: {
@@ -25604,7 +25604,7 @@ void main() {
     )
   };
 
-  // node_modules/three/examples/jsm/postprocessing/SMAAPass.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/postprocessing/SMAAPass.js
   var SMAAPass = class extends Pass {
     constructor(width, height) {
       super();
@@ -25717,7 +25717,7 @@ void main() {
     }
   };
 
-  // node_modules/three/examples/jsm/shaders/OutputShader.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/shaders/OutputShader.js
   var OutputShader = {
     name: "OutputShader",
     uniforms: {
@@ -25801,7 +25801,7 @@ void main() {
     )
   };
 
-  // node_modules/three/examples/jsm/postprocessing/OutputPass.js
+  // tools/chess3d-renderer/node_modules/three/examples/jsm/postprocessing/OutputPass.js
   var OutputPass = class extends Pass {
     constructor() {
       super();
@@ -25848,13 +25848,17 @@ void main() {
     }
   };
 
-  // chess3d-renderer.js
+  // tools/chess3d-renderer/chess3d-renderer.js
   var PIECE_SCALE = 0.5;
   var SS = 1.5;
   var SS_CAP = 2.5;
   var BLOOM_STRENGTH = 0.7;
   var BLOOM_RADIUS = 0.5;
   var BLOOM_THRESHOLD = 0.6;
+  var WHITE_MEAN = [0.427, 0.361, 0.263];
+  var BLACK_MEAN = [0.176, 0.114, 0.075];
+  var GRAIN_STRENGTH = 0.5;
+  var PIECE_ROUGHNESS = 0.4;
   var composer;
   var bloomPass;
   var smaaPass;
@@ -26021,6 +26025,27 @@ void main() {
       camera = null;
     }
   };
+  function debandPieceMaterial(mat, meanSrgb) {
+    if (!mat) return;
+    mat.roughnessMap = null;
+    mat.roughness = PIECE_ROUGHNESS;
+    mat.metalnessMap = null;
+    mat.metalness = 0;
+    const meanLin = new Vector3(
+      Math.pow(meanSrgb[0], 2.2),
+      Math.pow(meanSrgb[1], 2.2),
+      Math.pow(meanSrgb[2], 2.2)
+    );
+    mat.onBeforeCompile = (shader) => {
+      shader.uniforms.uGrainMean = { value: meanLin };
+      shader.uniforms.uGrainStrength = { value: GRAIN_STRENGTH };
+      shader.fragmentShader = "uniform vec3 uGrainMean;\nuniform float uGrainStrength;\n" + shader.fragmentShader.replace(
+        "#include <map_fragment>",
+        "#include <map_fragment>\n  diffuseColor.rgb = mix(uGrainMean, diffuseColor.rgb, uGrainStrength);"
+      );
+    };
+    mat.needsUpdate = true;
+  }
   async function loadGlb() {
     const loader = new GLTFLoader();
     const paths = ["./chess.glb", "chess.glb", "/app/src/commonMain/composeResources/files/models/chess.glb"];
@@ -26039,6 +26064,8 @@ void main() {
     const materials = await gltf.parser.getDependencies("material");
     whiteMat = materials.find((m) => m.name === "white") || materials[0] || null;
     blackMat = materials.find((m) => m.name === "black") || whiteMat;
+    debandPieceMaterial(whiteMat, WHITE_MEAN);
+    debandPieceMaterial(blackMat, BLACK_MEAN);
     gltf.scene.traverse((o) => {
       const name = o.name ? o.name.toLowerCase() : "";
       if (name && PIECE_NAMES.has(name)) pieceTemplates[name] = o;

--- a/iosApp/iosApp/Resources/chess3d-bundle.js
+++ b/iosApp/iosApp/Resources/chess3d-bundle.js
@@ -25852,9 +25852,9 @@ void main() {
   var PIECE_SCALE = 0.5;
   var SS = 1.5;
   var SS_CAP = 2.5;
-  var BLOOM_STRENGTH = 0.25;
-  var BLOOM_RADIUS = 0.4;
-  var BLOOM_THRESHOLD = 0.85;
+  var BLOOM_STRENGTH = 0.7;
+  var BLOOM_RADIUS = 0.5;
+  var BLOOM_THRESHOLD = 0.6;
   var composer;
   var bloomPass;
   var smaaPass;

--- a/iosApp/iosApp/Resources/chess3d-bundle.js
+++ b/iosApp/iosApp/Resources/chess3d-bundle.js
@@ -25852,9 +25852,9 @@ void main() {
   var PIECE_SCALE = 0.5;
   var SS = 1.5;
   var SS_CAP = 2.5;
-  var BLOOM_STRENGTH = 0.7;
-  var BLOOM_RADIUS = 0.5;
-  var BLOOM_THRESHOLD = 0.6;
+  var BLOOM_STRENGTH = 0.35;
+  var BLOOM_RADIUS = 0.4;
+  var BLOOM_THRESHOLD = 0.85;
   var WHITE_MEAN = [0.427, 0.361, 0.263];
   var BLACK_MEAN = [0.176, 0.114, 0.075];
   var GRAIN_STRENGTH = 0.5;

--- a/tools/chess3d-renderer/chess3d-renderer.js
+++ b/tools/chess3d-renderer/chess3d-renderer.js
@@ -15,12 +15,28 @@ import * as THREE from 'three'
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js'
 import { RGBELoader } from 'three/addons/loaders/RGBELoader.js'
 import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js'
+// Part C: EffectComposer supplies both crisper AA (HalfFloat MSAA render target + supersample +
+// SMAA) and bloom. Pinned to three@0.169.0 via the import map (web) / esbuild (iOS bundle).
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js'
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js'
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
+import { SMAAPass } from 'three/addons/postprocessing/SMAAPass.js'
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js'
 
 // The board lives in the game's ±4 space (1-unit squares). chess.glb is authored at ±8 with
 // 2-unit squares, so every glb node is scaled by 0.5 — matching Android's scale=0.5 exactly.
 // Piece world coordinates now arrive already in this ±4 space from Kotlin (Board3DScene/BoardGeometry
 // via chess3d.setScene), including the animated y (move arc hop + selection bounce).
 const PIECE_SCALE = 0.5
+// Part C AA + bloom tunables. SS supersamples the render buffer (sharper silhouettes / sculpt
+// detail — the main web regression was MSAA-only softness); SS_CAP bounds the fill-rate cost.
+const SS = 1.5            // render-buffer supersample factor (sharpness)
+const SS_CAP = 2.5        // hard cap on the effective pixel ratio
+const BLOOM_STRENGTH = 0.25
+const BLOOM_RADIUS = 0.4
+const BLOOM_THRESHOLD = 0.85
+let composer, bloomPass, smaaPass   // alongside `renderer, scene, camera`
+let usePost = false                 // set true once the composer builds; falls back to bare render
 // Glb node names that are piece templates (kept at origin as geometry sources) or stray helpers
 // (the "Plane" shadow catcher Android also hides). Everything else (a1..h8 tiles + frame) is shown.
 const HIDDEN_NODES = new Set(['king', 'queen', 'rook', 'bishop', 'knight', 'pawn', 'plane'])
@@ -72,7 +88,10 @@ window.chess3d = {
       // A re-init builds a fresh scene; drop pool slots pointing at the previous scene's nodes.
       piecePool.length = 0
       renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: false })
-      renderer.setPixelRatio(window.devicePixelRatio || 1)
+      // Part C: supersample the render buffer for crisper edges (the web regression was MSAA-only
+      // softness). The composer below renders into a HalfFloat MSAA target so AA stays sharp and
+      // bloom can work in HDR before the OutputPass tonemaps.
+      renderer.setPixelRatio(Math.min((window.devicePixelRatio || 1) * SS, SS_CAP))
       // Android (the visual reference) has NO cast shadows — it's lit purely by the papermill IBL,
       // whose radiance cube bakes in the sun's direction so the lighting already reads as sunlight
       // and stays fixed relative to the world as the camera orbits (as it would in nature). Adding
@@ -93,6 +112,26 @@ window.chess3d = {
       // Selection is shown by bouncing the picked piece (its y oscillates in setScene), not a disc.
 
       await loadGlb()
+      // Part C: build the post chain. RenderPass -> UnrealBloom (HDR) -> SMAA (edge AA) -> OutputPass
+      // (tonemap + sRGB). Wrapped so any addon/load failure falls back to the bare render loop below
+      // rather than a black canvas.
+      try {
+        const size = renderer.getDrawingBufferSize(new THREE.Vector2())
+        const rt = new THREE.WebGLRenderTarget(size.x, size.y, {
+          type: THREE.HalfFloatType, samples: 4, // MSAA-resolved HDR input = crisp silhouettes
+        })
+        composer = new EffectComposer(renderer, rt)
+        composer.addPass(new RenderPass(scene, camera))
+        bloomPass = new UnrealBloomPass(new THREE.Vector2(size.x, size.y), BLOOM_STRENGTH, BLOOM_RADIUS, BLOOM_THRESHOLD)
+        composer.addPass(bloomPass)
+        smaaPass = new SMAAPass(size.x, size.y)
+        composer.addPass(smaaPass)
+        composer.addPass(new OutputPass())
+        usePost = true
+      } catch (e) {
+        console.warn('[chess3d] EffectComposer init failed; falling back to bare render', e)
+        composer = null; bloomPass = null; smaaPass = null; usePost = false
+      }
       animate()
       return true
     } catch (e) {
@@ -156,12 +195,22 @@ window.chess3d = {
 
   resize(w, h) {
     if (!renderer) return
+    renderer.setPixelRatio(Math.min((window.devicePixelRatio || 1) * SS, SS_CAP))
     renderer.setSize(w, h, false)
     camera.aspect = w / h
     camera.updateProjectionMatrix()
+    // Part C: keep the composer + its passes in sync with the (supersampled) drawing buffer.
+    if (composer || bloomPass || smaaPass) {
+      const s = renderer.getDrawingBufferSize(new THREE.Vector2())
+      if (composer) composer.setSize(s.x, s.y)
+      if (bloomPass) bloomPass.setSize(s.x, s.y)
+      if (smaaPass) smaaPass.setSize(s.x, s.y)
+    }
   },
 
   dispose() {
+    if (composer) { composer.dispose(); composer = null }
+    bloomPass = null; smaaPass = null; usePost = false
     if (renderer) { renderer.dispose(); renderer = null }
     scene = null
     camera = null
@@ -227,5 +276,8 @@ async function loadGlb() {
 
 function animate() {
   requestAnimationFrame(animate)
-  if (renderer && scene && camera) renderer.render(scene, camera)
+  if (!renderer || !scene || !camera) return
+  // Part C: drive the post chain when the composer built; otherwise fall back to the bare render.
+  if (usePost && composer) composer.render()
+  else renderer.render(scene, camera)
 }

--- a/tools/chess3d-renderer/chess3d-renderer.js
+++ b/tools/chess3d-renderer/chess3d-renderer.js
@@ -32,12 +32,12 @@ const PIECE_SCALE = 0.5
 // detail — the main web regression was MSAA-only softness); SS_CAP bounds the fill-rate cost.
 const SS = 1.5            // render-buffer supersample factor (sharpness)
 const SS_CAP = 2.5        // hard cap on the effective pixel ratio
-// Bloom tuned to match Android's punchier warm halo: lower threshold so sunlit areas + specular
-// hotspots bloom, higher strength + wider radius for the dramatic "blown-out window" feel. The
-// papermill sun is warm, so its bloom reads warm without a separate tint.
-const BLOOM_STRENGTH = 0.7
-const BLOOM_RADIUS = 0.5
-const BLOOM_THRESHOLD = 0.6
+// Bloom tuned to a subtle Android-matching halo. The earlier punchy preset (strength 0.7 /
+// threshold 0.6) blew out the whole bright board centre; raise the threshold so only the brightest
+// specular/sun highlights bloom, and lower the strength so it reads as atmosphere, not glare.
+const BLOOM_STRENGTH = 0.35
+const BLOOM_RADIUS = 0.4
+const BLOOM_THRESHOLD = 0.85
 // De-band (mirrors the desktop Vulkan renderer): the glb whites/blacks albedo bakes high-contrast
 // horizontal wood grain and the shared metallicRoughness map's green channel is striped too, so on
 // the lathe-turned pieces both wrap into hard rings. We soften the albedo grain toward the per-

--- a/tools/chess3d-renderer/chess3d-renderer.js
+++ b/tools/chess3d-renderer/chess3d-renderer.js
@@ -38,6 +38,15 @@ const SS_CAP = 2.5        // hard cap on the effective pixel ratio
 const BLOOM_STRENGTH = 0.7
 const BLOOM_RADIUS = 0.5
 const BLOOM_THRESHOLD = 0.6
+// De-band (mirrors the desktop Vulkan renderer): the glb whites/blacks albedo bakes high-contrast
+// horizontal wood grain and the shared metallicRoughness map's green channel is striped too, so on
+// the lathe-turned pieces both wrap into hard rings. We soften the albedo grain toward the per-
+// material mean wood colour and flatten roughness to a constant (even sheen, not glossy/matte bands).
+// Means measured from the glb albedos (sRGB).
+const WHITE_MEAN = [0.427, 0.361, 0.263]
+const BLACK_MEAN = [0.176, 0.114, 0.075]
+const GRAIN_STRENGTH = 0.5   // 1 = full grain; 0 = flat colour. 0.5 keeps subtle character.
+const PIECE_ROUGHNESS = 0.4  // constant roughness for pieces (replaces the striped roughnessMap)
 let composer, bloomPass, smaaPass   // alongside `renderer, scene, camera`
 let usePost = false                 // set true once the composer builds; falls back to bare render
 // Glb node names that are piece templates (kept at origin as geometry sources) or stray helpers
@@ -220,6 +229,37 @@ window.chess3d = {
   },
 }
 
+// De-band a shared piece material in place (see WHITE_MEAN/BLACK_MEAN comment). Flattens the striped
+// roughness/metalness maps to constants, and injects a tiny shader patch that pulls the sampled
+// albedo toward the per-material mean wood colour so the baked grain reads as subtle texture, not
+// hard rings — the three.js analogue of the desktop renderer's grainStrength/roughnessOverride.
+function debandPieceMaterial(mat, meanSrgb) {
+  if (!mat) return
+  // Flatten roughness: the glb metallicRoughness map's green channel is striped. Drop the map and
+  // use a constant; also drop the metalness map (wood is dielectric) so it can't add banding.
+  mat.roughnessMap = null
+  mat.roughness = PIECE_ROUGHNESS
+  mat.metalnessMap = null
+  mat.metalness = 0.0
+  // Soften the striped albedo grain toward the linearised mean. The map is sampled into linear space
+  // (three colour management), so `diffuseColor.rgb` after <map_fragment> is linear — mix toward the
+  // linearised mean there. GRAIN_STRENGTH == 1 would be a no-op.
+  const meanLin = new THREE.Vector3(
+    Math.pow(meanSrgb[0], 2.2), Math.pow(meanSrgb[1], 2.2), Math.pow(meanSrgb[2], 2.2),
+  )
+  mat.onBeforeCompile = (shader) => {
+    shader.uniforms.uGrainMean = { value: meanLin }
+    shader.uniforms.uGrainStrength = { value: GRAIN_STRENGTH }
+    shader.fragmentShader =
+      'uniform vec3 uGrainMean;\nuniform float uGrainStrength;\n' +
+      shader.fragmentShader.replace(
+        '#include <map_fragment>',
+        '#include <map_fragment>\n  diffuseColor.rgb = mix(uGrainMean, diffuseColor.rgb, uGrainStrength);',
+      )
+  }
+  mat.needsUpdate = true
+}
+
 async function loadGlb() {
   const loader = new GLTFLoader()
   const paths = ['./chess.glb', 'chess.glb', '/app/src/commonMain/composeResources/files/models/chess.glb']
@@ -237,6 +277,8 @@ async function loadGlb() {
   const materials = await gltf.parser.getDependencies('material')
   whiteMat = materials.find(m => m.name === 'white') || materials[0] || null
   blackMat = materials.find(m => m.name === 'black') || whiteMat
+  debandPieceMaterial(whiteMat, WHITE_MEAN)
+  debandPieceMaterial(blackMat, BLACK_MEAN)
 
   // Stash the six piece template meshes by kind (they sit at the glb origin).
   gltf.scene.traverse(o => {

--- a/tools/chess3d-renderer/chess3d-renderer.js
+++ b/tools/chess3d-renderer/chess3d-renderer.js
@@ -32,9 +32,12 @@ const PIECE_SCALE = 0.5
 // detail — the main web regression was MSAA-only softness); SS_CAP bounds the fill-rate cost.
 const SS = 1.5            // render-buffer supersample factor (sharpness)
 const SS_CAP = 2.5        // hard cap on the effective pixel ratio
-const BLOOM_STRENGTH = 0.25
-const BLOOM_RADIUS = 0.4
-const BLOOM_THRESHOLD = 0.85
+// Bloom tuned to match Android's punchier warm halo: lower threshold so sunlit areas + specular
+// hotspots bloom, higher strength + wider radius for the dramatic "blown-out window" feel. The
+// papermill sun is warm, so its bloom reads warm without a separate tint.
+const BLOOM_STRENGTH = 0.7
+const BLOOM_RADIUS = 0.5
+const BLOOM_THRESHOLD = 0.6
 let composer, bloomPass, smaaPass   // alongside `renderer, scene, camera`
 let usePost = false                 // set true once the composer builds; falls back to bare render
 // Glb node names that are piece templates (kept at origin as geometry sources) or stray helpers


### PR DESCRIPTION
Closes the remaining 3D visual-parity gaps against the Android (Filament) reference, across desktop, web, and iOS. Full plan + findings in `docs/plans/3d-parity-desktop-bloom-web-aa.md`.

## What's in here
**Desktop (Vulkan)** — materials + lighting were flat/matte vs Android:
- Glossier pieces (IBL specular 0.5→0.85), glTF occlusion (`mrTex.r`) + contact-shadow grounding, warmer tone.
- New HDR **bloom** post pipeline (bright-pass → separable blur → composite tonemap), `CHESS_DESKTOP_BLOOM` kill-switch.

**Web + iOS (three.js)** — the frame was soft (MSAA-only):
- `EffectComposer` chain: HalfFloat MSAA target + supersample + `UnrealBloomPass` + `SMAAPass` + `OutputPass`.

**De-band striped pieces (desktop + web/iOS)** — the `chess.glb` whites/blacks **albedo bakes high-contrast horizontal wood grain** and the shared `metallicRoughness` **green channel is striped too**, so on the lathe-turned pieces both wrap into hard rings — and the gloss boost above *amplified* them. Fix (pieces only; board untouched):
- Soften albedo grain toward the per-material mean wood colour (`grainStrength`).
- Flatten roughness to a constant (`roughnessOverride`), so no glossy/matte ring alternation.
- Desktop: in `FRAG_GLSL` + push constants. Web/iOS: `debandPieceMaterial()` (`onBeforeCompile` patch + `roughnessMap=null`) in the shared `chess3d-renderer.js`, regenerated into both copies.

**iOS render fix (discovered during verification)** — the iOS board rendered **blank navy**: WKWebView blocks `XMLHttpRequest`/`fetch` of `file://` resources even under `loadFileURL(allowingReadAccessToURL:)`, so three.js's `GLTFLoader`/`RGBELoader` failed (`Load failed`). The KVC `allowFileAccessFromFileURLs` pref isn't exposed in Kotlin/Native, so this registers a custom **`WKURLSchemeHandler`** (`chessasset://`) for the bundled assets and loads the host through it.

## Verification
- **Desktop:** `DesktopRendererSmokeTest -Dchess3d.smoke=true` — rings gone, glossier/warmer, bloom present.
- **iOS:** `tools/ios_3d_screenshot.sh` — board renders with de-banded pieces (was blank before the scheme-handler fix).
- **Web:** `:app:compileKotlinWasmJs` builds with the regenerated renderer string.
- Android untouched.