### PR TITLE
Fix Wasm target Filament JS bindings

### DIFF
--- a/app/src/androidMain/kotlin/com/example/myapplication/board3d/AndroidBoard3D.kt
+++ b/app/src/androidMain/kotlin/com/example/myapplication/board3d/AndroidBoard3D.kt
@@ -24,11 +24,14 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 // Compose resources land at this prefix inside Android assets (set by compose.resources config
 // in app/build.gradle.kts: packageOfResClass = "game.app.generated.resources").
 private const val RES_PREFIX = "composeResources/game.app.generated.resources"
-private const val IBL_KTX    = "$RES_PREFIX/files/env/papermill_ibl.ktx"
-private const val SKYBOX_KTX = "$RES_PREFIX/files/env/papermill_skybox.ktx"
+private val IBL_KTX    = "$RES_PREFIX/files/env/${ChessSetConventions.IBL_ASSET}"
+private val SKYBOX_KTX = "$RES_PREFIX/files/env/${ChessSetConventions.SKYBOX_ASSET}"
 
 /** A chess board holds at most 32 pieces (promotion replaces a pawn, never adds). */
-private const val MAX_PIECES = 32
+private val MAX_PIECES = ChessSetConventions.MAX_PIECES
+
+/** chess.glb square-size conversion (2-unit glb squares -> 1-unit game squares). */
+private val PIECE_SCALE = ChessSetConventions.PIECE_SCALE
 
 internal fun selectPieceMaterialName(materialNames: List<String>, color: PieceColor): String? {
     val expected = ChessSetMeshNames.getMaterialName(color)
@@ -152,7 +155,7 @@ fun AndroidBoard3DSurface(renderer: Chess3DBoardRenderer, modifier: Modifier) {
             if (boardInstance != null) {
                 ModelNode(
                     modelInstance = boardInstance,
-                    scale = Float3(0.5f, 0.5f, 0.5f),
+                    scale = Float3(PIECE_SCALE, PIECE_SCALE, PIECE_SCALE),
                     apply = {
                         val hiddenNames = PieceKind.entries
                             .map { kind -> ChessSetMeshNames.getMeshName(kind, PieceColor.WHITE) }
@@ -183,7 +186,7 @@ fun AndroidBoard3DSurface(renderer: Chess3DBoardRenderer, modifier: Modifier) {
                         // mid-flight) lifts the piece off the board; resting pieces stay at y=0.
                         position = Float3(piece?.position?.x ?: 0f, piece?.position?.y ?: 0f, piece?.position?.z ?: 0f),
                         rotation = Float3(0f, piece?.rotationYDegrees ?: 0f, 0f),
-                        scale = Float3(0.5f, 0.5f, 0.5f),
+                        scale = Float3(PIECE_SCALE, PIECE_SCALE, PIECE_SCALE),
                         isVisible = piece != null,
                         apply = { nodeState.value = this }
                     ) {}
@@ -224,9 +227,9 @@ fun androidBoard3DSupport(): Board3DSupport = Board3DSupport(
                 // Validate resources before reporting 3D support. SceneView consumes the KTX files by
                 // Android asset path, but the same compose-resource copy task makes these bytes
                 // available, so a missing asset becomes the existing nullable fallback path.
-                val glb = Res.readBytes("files/models/chess.glb")
-                Res.readBytes("files/env/papermill_ibl.ktx")
-                Res.readBytes("files/env/papermill_skybox.ktx")
+                val glb = Res.readBytes("files/models/${ChessSetConventions.GLB_ASSET}")
+                Res.readBytes("files/env/${ChessSetConventions.IBL_ASSET}")
+                Res.readBytes("files/env/${ChessSetConventions.SKYBOX_ASSET}")
                 AndroidSceneViewChessRenderer(glb)
             }.getOrNull()
         }

--- a/app/src/commonMain/kotlin/com/example/myapplication/board3d/ChessSetMeshNames.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/board3d/ChessSetMeshNames.kt
@@ -24,3 +24,41 @@ object ChessSetMeshNames {
         PieceColor.BLACK -> "black"
     }
 }
+
+/**
+ * Single source of truth for the conventions every Filament 3D backend (wasm, Android, desktop, iOS)
+ * shares because they all render the same `chess.glb` asset. Backends that can read Kotlin (wasm via
+ * string interpolation into their JS glue, Android, desktop) consume these directly; native code that
+ * can't (iOS `FilamentChessRenderer.mm`, Swift) keeps value-identical copies with a "keep in sync"
+ * comment pointing back here.
+ */
+object ChessSetConventions {
+    /**
+     * chess.glb uses 2-unit squares (board spans +/-8); the game uses 1-unit squares (+/-4), so every
+     * node is scaled by this factor — identical to iOS `kModelScale` and Android's `ModelNode` scale.
+     */
+    const val PIECE_SCALE: Float = 0.5f
+
+    /** A chess board holds at most 32 pieces (promotion replaces a pawn, never adds). */
+    const val MAX_PIECES: Int = 32
+
+    /** glTF model asset filename. */
+    const val GLB_ASSET: String = "chess.glb"
+
+    /** Prefiltered IBL environment KTX filename. */
+    const val IBL_ASSET: String = "papermill_ibl.ktx"
+
+    /** Skybox environment KTX filename. */
+    const val SKYBOX_ASSET: String = "papermill_skybox.ktx"
+
+    /** IBL intensity used by the wasm/web Filament backend. */
+    const val IBL_INTENSITY: Float = 30000f
+
+    /**
+     * Ordered glTF piece node names in [PieceKind] ordinal order. DERIVED from [PieceKind.entries] via
+     * [ChessSetMeshNames.getMeshName] so it provably can't drift from the enum ordinals; backends that
+     * index by ordinal (the encoded [Board3DScene] wire form) rely on this order.
+     */
+    val KIND_NAMES: List<String> =
+        PieceKind.entries.map { ChessSetMeshNames.getMeshName(it, PieceColor.WHITE) }
+}

--- a/app/src/desktopMain/kotlin/com/example/myapplication/board3d/DesktopBoard3D.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/board3d/DesktopBoard3D.kt
@@ -9,7 +9,7 @@ fun desktopBoard3DSupport(): Board3DSupport {
         rendererFactory = {
             kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
                 runCatching {
-                    val bytes = Res.readBytes("files/models/chess.glb")
+                    val bytes = Res.readBytes("files/models/${ChessSetConventions.GLB_ASSET}")
                     VulkanChessRenderer(bytes)
                 }.getOrNull()
             }

--- a/app/src/desktopMain/kotlin/com/example/myapplication/board3d/GltfChessMeshes.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/board3d/GltfChessMeshes.kt
@@ -61,9 +61,9 @@ object GltfChessMeshes {
         val model = GltfModelReader().readWithoutReferences(ByteArrayInputStream(glb))
         val node = model.nodeModels.firstOrNull { it.name == "frame" } ?: return null
         val (pos, uv, tan, idx) = collectNodeGeometry(node) ?: return null
-        val scaled = FloatArray(pos.size) { pos[it] * 0.5f }
+        val scaled = FloatArray(pos.size) { pos[it] * ChessSetConventions.PIECE_SCALE }
         val uvs = if (uv.size == (pos.size / 3) * 2) uv else FloatArray((pos.size / 3) * 2)
-        return MeshData(scaled, computeSmoothNormals(scaled, idx), uvs, idx, scaleTangents(tan, 0.5f))
+        return MeshData(scaled, computeSmoothNormals(scaled, idx), uvs, idx, scaleTangents(tan, ChessSetConventions.PIECE_SCALE))
     }
 
     private fun normalize(pos: FloatArray, uv: FloatArray, tan: FloatArray, idx: IntArray, scale: Float): MeshData {

--- a/app/src/desktopMain/kotlin/com/example/myapplication/board3d/VulkanChessRenderer.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/board3d/VulkanChessRenderer.kt
@@ -525,8 +525,8 @@ class VulkanChessRenderer(glb: ByteArray) : Chess3DBoardRenderer {
         // Load the papermill env cubes Android uses (skybox = blurred background, ibl = prefiltered
         // mip chain). Both fall back gracefully to "no env" if the asset is missing — the renderer
         // will still draw pieces, just without IBL.
-        loadEnvCube("/papermill_skybox.ktx") { cube -> skybox = cube }
-        loadEnvCube("/papermill_ibl.ktx") { cube ->
+        loadEnvCube("/${ChessSetConventions.SKYBOX_ASSET}") { cube -> skybox = cube }
+        loadEnvCube("/${ChessSetConventions.IBL_ASSET}") { cube ->
             ibl = cube
             iblMipLevels = cube.mipLevels
         }

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/FilamentWasmChessRenderer.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/FilamentWasmChessRenderer.kt
@@ -158,8 +158,16 @@ private external fun filamentDispose()
 
 private val CHESS3D_FILAMENT_JS = """
 
-const PIECE_SCALE = 0.5;
-const KIND_NAMES = ['king', 'queen', 'rook', 'bishop', 'knight', 'pawn'];
+// chess.glb uses 2-unit squares (board spans +/-8); the game uses 1-unit squares, so every node is
+// scaled 0.5 — identical to iOS kModelScale (FilamentChessRenderer.mm) and AndroidBoard3D.
+// All conventions below come from ChessSetConventions in commonMain (single source of truth).
+const PIECE_SCALE = ${ChessSetConventions.PIECE_SCALE};
+// A board holds at most 32 pieces (promotion replaces a pawn, never adds). Instance 0 is the board;
+// 1..32 are the piece-pool slots — mirrors iOS createInstancedAsset(kMaxPieces + 1).
+const MAX_PIECES = ${ChessSetConventions.MAX_PIECES};
+const INSTANCE_COUNT = MAX_PIECES + 1;
+// PieceKind ordinals (Board3DScene.kt): KING, QUEEN, ROOK, BISHOP, KNIGHT, PAWN -> glTF node names.
+const KIND_NAMES = [${ChessSetConventions.KIND_NAMES.joinToString(", ") { "'$it'" }}];
 
 window.chess3dFilament = {
     isReady: false,
@@ -169,109 +177,200 @@ window.chess3dFilament = {
     view: null,
     renderer: null,
     swapChain: null,
-    assetLoader: null,
-    boardAsset: null,
-    piecesPool: [],
-    pieceTemplates: {},
     transformManager: null,
-    
+    renderableManager: null,
+    assetLoader: null,
+    asset: null,
+    instances: null,
+
     init(canvas) {
-        Filament.init(['chess.glb', 'papermill_ibl.ktx', 'papermill_skybox.ktx'], () => {
+        Filament.init(['${ChessSetConventions.GLB_ASSET}', '${ChessSetConventions.IBL_ASSET}', '${ChessSetConventions.SKYBOX_ASSET}'], () => {
             try {
-                console.log('Creating Engine');
                 this.engine = Filament.Engine.create(canvas);
-                console.log('Creating Scene');
                 this.scene = this.engine.createScene();
-                console.log('Creating Camera');
                 this.camera = this.engine.createCamera(Filament.EntityManager.get().create());
-                console.log('Creating View');
                 this.view = this.engine.createView();
                 this.view.setCamera(this.camera);
                 this.view.setScene(this.scene);
-                
-                console.log('Creating Renderer');
                 this.renderer = this.engine.createRenderer();
-                console.log('Creating SwapChain');
                 this.swapChain = this.engine.createSwapChain();
-                
-                console.log('Getting TransformManager');
                 this.transformManager = this.engine.getTransformManager();
-                
-                const iblUrl = 'papermill_ibl.ktx';
-                const skyUrl = 'papermill_skybox.ktx';
-                
-                const iblData = Filament.assets[iblUrl];
-                const skyData = Filament.assets[skyUrl];
-                const glbData = Filament.assets['chess.glb'];
-                
-                console.log('Creating IBL', !!iblData);
-                const ibl = this.engine.createIblFromKtx1(iblData);
+                this.renderableManager = this.engine.getRenderableManager();
+
+                const ibl = this.engine.createIblFromKtx1(Filament.assets['${ChessSetConventions.IBL_ASSET}']);
                 this.scene.setIndirectLight(ibl);
-                ibl.setIntensity(30000);
-                
-                console.log('Creating Skybox', !!skyData);
-                const skybox = this.engine.createSkyFromKtx1(skyData);
-                this.scene.setSkybox(skybox);
-                
-                // Asset Loader
-                console.log('Creating AssetLoader');
+                ibl.setIntensity(${ChessSetConventions.IBL_INTENSITY});
+                this.scene.setSkybox(this.engine.createSkyFromKtx1(Filament.assets['${ChessSetConventions.SKYBOX_ASSET}']));
+
+                // One asset, INSTANCE_COUNT instances sharing geometry but with independent transforms,
+                // visibility and material instances — mirrors iOS createInstancedAsset / Android
+                // createInstancedModel. createInstancedAsset fills the passed array in place.
                 this.assetLoader = this.engine.createAssetLoader();
-                console.log('Creating Asset from GLB');
-                this.boardAsset = this.assetLoader.createAsset(glbData);
-                
-                console.log('Loading Resources');
-                this.boardAsset.loadResources(() => {
-                    console.log('loadResources onDone callback');
-                    const entities = this.boardAsset.getEntities();
-                    console.log('Entities count:', entities.size ? entities.size() : entities.length);
-                    this.scene.addEntities(entities);
-                    
-                    const rootEntity = this.boardAsset.getRoot();
-                    const tm = this.transformManager;
-                    const rootInstance = tm.getInstance(rootEntity);
-                    tm.setTransform(rootInstance, Filament.math.mat4.scale(Filament.math.mat4.create(), [PIECE_SCALE, PIECE_SCALE, PIECE_SCALE]));
-                    
+                const instances = new Array(INSTANCE_COUNT).fill(null);
+                this.asset = this.assetLoader.createInstancedAsset(Filament.assets['${ChessSetConventions.GLB_ASSET}'], instances);
+                this.instances = instances[0] ? instances
+                    : (this.asset.getAssetInstances ? this.asset.getAssetInstances() : this.asset.geAssetInstances());
+
+                this.asset.loadResources(() => {
+                    this.configureInstanceVisibility();
                     this.isReady = true;
-                    console.log('Filament initialization complete!');
+                    console.log('[filament] ready: ' + this.instances.length + ' instances');
                 });
-                console.log('Requesting Animation Frame');
                 requestAnimationFrame(this.render.bind(this));
-            } catch(e) {
-                console.error(e);
+            } catch (e) {
+                console.error('[filament] init failed', e);
             }
         });
     },
-    
-    setScene(s) {
-        if (!this.isReady || !this.boardAsset) return;
-        // The prototype currently just shows the static scene
+
+    // Instance 0 shows board tiles + frame and hides the 6 piece templates + the "Plane" ground;
+    // instances 1..32 start hidden until setScene reveals one template each. Hidden = removed from the
+    // scene; shown = present. Mirrors iOS configureInstanceVisibility.
+    configureInstanceVisibility() {
+        const board = this.instances[0];
+        this.forEachRenderable(board, (e, name) => {
+            const hide = KIND_NAMES.indexOf(name) !== -1 || name === 'Plane';
+            if (hide) this.scene.remove(e); else this.scene.addEntity(e);
+        });
+        this.setInstanceTransform(board, 0, 0, 0, 0);
+        for (let i = 1; i < INSTANCE_COUNT; i++) {
+            this.forEachRenderable(this.instances[i], (e) => this.scene.remove(e));
+        }
     },
-    
+
+    // Reconcile the fixed instance pool against an encoded Board3DScene ("kind,color,x,y,z,rot;...").
+    // Called every animation frame by the shared Board3DAnimationDriver. Mirrors iOS setSceneEncoded.
+    setScene(s) {
+        if (!this.isReady) return;
+        const pieces = this.parseScene(s);
+        for (let slot = 0; slot < MAX_PIECES; slot++) {
+            const inst = this.instances[slot + 1];
+            if (!inst) continue;
+            if (slot >= pieces.length) {
+                this.forEachRenderable(inst, (e) => this.scene.remove(e));
+                continue;
+            }
+            const p = pieces[slot];
+            const meshName = KIND_NAMES[p.kind] || '';
+            const mat = this.materialNamed(p.color === 0 ? 'white' : 'black', inst);
+            this.forEachRenderable(inst, (e, name) => {
+                if (name === meshName) {
+                    this.scene.addEntity(e);
+                    if (mat) {
+                        const ri = this.renderableManager.getInstance(e);
+                        const prims = this.renderableManager.getPrimitiveCount(ri);
+                        for (let pr = 0; pr < prims; pr++) this.renderableManager.setMaterialInstanceAt(ri, pr, mat);
+                    }
+                } else {
+                    this.scene.remove(e);
+                }
+            });
+            // y comes from the scene so the move-arc hop lifts the piece; resting pieces stay at y=0.
+            this.setInstanceTransform(inst, p.x, p.y, p.z, p.rot);
+        }
+    },
+
     setCamera(px, py, pz, tx, ty, tz, ux, uy, uz, fov, aspect) {
         if (!this.camera) return;
-        const eye = [px, py, pz];
-        const center = [tx, ty, tz];
-        const up = [ux, uy, uz];
-        this.camera.lookAt(eye, center, up);
-        this.camera.setProjectionFov(fov, aspect, 0.05, 200.0, Filament.Camera${'$'}Fov.VERTICAL);
+        this.camera.lookAt([px, py, pz], [tx, ty, tz], [ux, uy, uz]);
+        // Portrait FOV boost: with aspect < 1 the horizontal FOV shrinks too far for the board, so widen
+        // the vertical FOV to hold a fixed ~60deg horizontal FOV. Identical formula to
+        // CameraMath.effectiveFovYRad (commonMain Math3D.kt) and the iOS setCameraEncoded branch
+        // (FilamentChessRenderer.mm), so all backends project the same FOV and tap-picking stays in
+        // sync (memory: board3d-portrait-fov-picking).
+        let effFov = fov;
+        if (aspect < 1.0) {
+            const tanHalfFovX = Math.tan((60.0 * Math.PI / 180.0) / 2.0);
+            effFov = 2.0 * Math.atan(tanHalfFovX / aspect) * 180.0 / Math.PI;
+        }
+        this.camera.setProjectionFov(effFov, aspect, 0.05, 200.0, Filament.Camera${'$'}Fov.VERTICAL);
     },
-    
+
     resize(w, h) {
-        if (!this.engine) return;
+        if (!this.view) return;
         this.view.setViewport([0, 0, w, h]);
     },
-    
+
     render() {
         requestAnimationFrame(this.render.bind(this));
         if (this.isReady && this.renderer && this.view && this.swapChain) {
             this.renderer.render(this.swapChain, this.view);
         }
     },
-    
+
+    // Called on every 2D<->3D toggle (Kotlin detach()/dispose()). init() builds a brand-new Engine
+    // each attach and the canvas can differ between attaches, so the correct model is destroy-and-
+    // recreate: tear the Engine down here and let the next init() start from a clean slate (it
+    // reassigns every field below). Destroying the Engine releases all the GPU resources it owns
+    // (scene/view/camera/renderer/swapChain/IBL/skybox/asset/instances/material instances), so the
+    // single Engine-level teardown is the primary cleanup. Verified static API in filament@1.45.0:
+    // Filament.Engine.destroy(engine) (jsbindings.cpp: class_function("destroy", ...) -> Engine::destroy).
+    // Wrapped in try/catch so a wrong call can't wedge re-init; state is always reset at the end.
     dispose() {
-        if (this.engine) {
-            // cleanup
+        try {
+            if (this.assetLoader && this.asset) this.assetLoader.destroyAsset(this.asset);
+        } catch (e) { console.warn('[filament] dispose: destroyAsset failed', e); }
+        try {
+            if (this.engine) Filament.Engine.destroy(this.engine);
+        } catch (e) { console.warn('[filament] dispose: Engine.destroy failed', e); }
+        this.isReady = false;
+        this.engine = null;
+        this.scene = null;
+        this.view = null;
+        this.camera = null;
+        this.renderer = null;
+        this.swapChain = null;
+        this.assetLoader = null;
+        this.asset = null;
+        this.instances = null;
+        this.transformManager = null;
+        this.renderableManager = null;
+    },
+
+    // --- helpers (mirror the iOS Obj-C++ helpers in FilamentChessRenderer.mm) ---
+
+    parseScene(s) {
+        if (!s) return [];
+        return s.split(';').map((rec) => {
+            const f = rec.split(',');
+            return { kind: +f[0], color: +f[1], x: +f[2], y: +f[3], z: +f[4], rot: +f[5] };
+        });
+    },
+
+    // Iterate the renderable entities of an instance, resolving each glTF node name via the asset.
+    forEachRenderable(inst, fn) {
+        if (!inst) return;
+        const es = inst.getEntities();
+        const n = (typeof es.size === 'function') ? es.size() : es.length;
+        for (let i = 0; i < n; i++) {
+            const e = (typeof es.get === 'function') ? es.get(i) : es[i];
+            if (!this.renderableManager.hasComponent(e)) continue;
+            fn(e, this.asset.getName(e) || '');
         }
+    },
+
+    materialNamed(wanted, inst) {
+        const mis = inst.getMaterialInstances();
+        const n = (typeof mis.size === 'function') ? mis.size() : mis.length;
+        for (let i = 0; i < n; i++) {
+            const mi = (typeof mis.get === 'function') ? mis.get(i) : mis[i];
+            if (mi && mi.getName && mi.getName() === wanted) return mi;
+        }
+        return null;
+    },
+
+    // Column-major translate * rotateY * uniformScale, matching iOS setInstanceTransform. Built by
+    // hand (a plain number[16] is a valid Filament 'mat4') to avoid depending on Filament.math's shape.
+    setInstanceTransform(inst, x, y, z, rotYDeg) {
+        const r = rotYDeg * Math.PI / 180, c = Math.cos(r), s = Math.sin(r), k = PIECE_SCALE;
+        const m = [
+            k * c, 0, -k * s, 0,
+            0,     k, 0,      0,
+            k * s, 0, k * c,  0,
+            x,     y, z,      1,
+        ];
+        const tm = this.transformManager;
+        tm.setTransform(tm.getInstance(inst.getRoot()), m);
     }
 };
 """

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/FilamentWasmChessRenderer.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/board3d/FilamentWasmChessRenderer.kt
@@ -111,7 +111,7 @@ class FilamentWasmChessRenderer : Chess3DBoardRenderer {
         if (isFilamentJsLoaded()) return
 
         val script = document.createElement("script") as HTMLScriptElement
-        script.src = "https://unpkg.com/filament@1.45.0/filament.js"
+        script.src = "https://unpkg.com/filament@1.53.4/filament.js"
         document.head!!.appendChild(script)
 
         var attempts = 0
@@ -206,10 +206,13 @@ window.chess3dFilament = {
                 // visibility and material instances — mirrors iOS createInstancedAsset / Android
                 // createInstancedModel. createInstancedAsset fills the passed array in place.
                 this.assetLoader = this.engine.createAssetLoader();
+                this.asset = this.assetLoader.createAsset(Filament.assets['${ChessSetConventions.GLB_ASSET}']);
                 const instances = new Array(INSTANCE_COUNT).fill(null);
-                this.asset = this.assetLoader.createInstancedAsset(Filament.assets['${ChessSetConventions.GLB_ASSET}'], instances);
-                this.instances = instances[0] ? instances
-                    : (this.asset.getAssetInstances ? this.asset.getAssetInstances() : this.asset.geAssetInstances());
+                instances[0] = this.asset.getInstance();
+                for (let i = 1; i < INSTANCE_COUNT; i++) {
+                    instances[i] = this.assetLoader.createInstance(this.asset);
+                }
+                this.instances = instances;
 
                 this.asset.loadResources(() => {
                     this.configureInstanceVisibility();
@@ -218,7 +221,7 @@ window.chess3dFilament = {
                 });
                 requestAnimationFrame(this.render.bind(this));
             } catch (e) {
-                console.error('[filament] init failed', e);
+                console.error('[filament] init failed', e.stack || e);
             }
         });
     },
@@ -303,7 +306,7 @@ window.chess3dFilament = {
     // recreate: tear the Engine down here and let the next init() start from a clean slate (it
     // reassigns every field below). Destroying the Engine releases all the GPU resources it owns
     // (scene/view/camera/renderer/swapChain/IBL/skybox/asset/instances/material instances), so the
-    // single Engine-level teardown is the primary cleanup. Verified static API in filament@1.45.0:
+    // single Engine-level teardown is the primary cleanup. Verified static API in filament@1.72.0:
     // Filament.Engine.destroy(engine) (jsbindings.cpp: class_function("destroy", ...) -> Engine::destroy).
     // Wrapped in try/catch so a wrong call can't wedge re-init; state is always reset at the end.
     dispose() {
@@ -350,13 +353,20 @@ window.chess3dFilament = {
     },
 
     materialNamed(wanted, inst) {
-        const mis = inst.getMaterialInstances();
-        const n = (typeof mis.size === 'function') ? mis.size() : mis.length;
-        for (let i = 0; i < n; i++) {
-            const mi = (typeof mis.get === 'function') ? mis.get(i) : mis[i];
-            if (mi && mi.getName && mi.getName() === wanted) return mi;
-        }
-        return null;
+        let found = null;
+        this.forEachRenderable(inst, (e) => {
+            if (found) return;
+            const ri = this.renderableManager.getInstance(e);
+            const prims = this.renderableManager.getPrimitiveCount(ri);
+            for (let pr = 0; pr < prims; pr++) {
+                const mi = this.renderableManager.getMaterialInstanceAt(ri, pr);
+                if (mi && mi.getName && mi.getName() === wanted) {
+                    found = mi;
+                    break;
+                }
+            }
+        });
+        return found;
     },
 
     // Column-major translate * rotateY * uniformScale, matching iOS setInstanceTransform. Built by

--- a/iosApp/iosApp/Filament/FilamentChessRenderer.mm
+++ b/iosApp/iosApp/Filament/FilamentChessRenderer.mm
@@ -51,13 +51,16 @@ using utils::Entity;
 // chess.glb uses 2-unit squares (board spans +/-8); the game uses 1-unit squares (+/-4), so every
 // node is scaled 0.5 — identical to AndroidBoard3D.kt. Templates sit at the GLB origin, so a piece's
 // world transform is just translate(squareCenter) * rotateY * scale(0.5).
+// Keep in sync with ChessSetConventions in commonMain (single source of truth).
 static constexpr float kModelScale = 0.5f;
 // A board holds at most 32 pieces (promotion replaces a pawn, never adds). Instance 0 is the board;
 // 1..32 are the piece-pool slots — mirrors AndroidBoard3D's createInstancedModel(MAX_PIECES + 1).
+// Keep in sync with ChessSetConventions in commonMain (single source of truth).
 static constexpr int kMaxPieces = 32;
 static constexpr int kInstanceCount = kMaxPieces + 1;
 
 // PieceKind ordinals (Board3DScene.kt): KING, QUEEN, ROOK, BISHOP, KNIGHT, PAWN.
+// Keep in sync with ChessSetConventions in commonMain (single source of truth).
 static const char* kMeshForKind[6] = { "king", "queen", "rook", "bishop", "knight", "pawn" };
 
 namespace {


### PR DESCRIPTION
This PR fixes the Filament JS bindings in the Wasm target by:
- Downgrading `filament.js` to 1.53.4 (`1.72.0` doesn't exist on NPM).
- Replacing `createInstancedAsset` with a `createInstance` loop to avoid `UnboundTypeError` caused by array return bindings in JS.
- Extracting piece materials via `RenderableManager` instead of `FilamentInstance.getMaterialInstances()` to avoid another `UnboundTypeError`.