### PR TITLE
Remove lingering Vulkan reference in desktop surface comment

### DIFF
--- a/app/src/desktopMain/kotlin/com/example/myapplication/board3d/ImageBitmapChess3DSurface.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/board3d/ImageBitmapChess3DSurface.kt
@@ -14,8 +14,9 @@ class ImageBitmapChess3DSurface(
 ) : Chess3DSurface
 
 /**
- * Wraps raw `width*height*4` RGBA8888 bytes (the layout the Vulkan renderer reads back from its
- * `RGBA8Unorm` color target) into a Compose [ImageBitmap] via Skia, with no channel swizzling.
+ * Wraps raw `width*height*4` RGBA8888 bytes (the layout the desktop Filament renderer reads back
+ * from its color target via `Renderer::readPixels`) into a Compose [ImageBitmap] via Skia, with no
+ * channel swizzling.
  */
 internal fun rgbaBytesToImageBitmap(rgba: ByteArray, w: Int, h: Int, bytesPerRow: Int = w * 4): ImageBitmap {
     val bitmap = Bitmap()


### PR DESCRIPTION
## Summary

Follow-up cleanup after #62. Fixes the one obsolete **Vulkan** reference left in current code: the `rgbaBytesToImageBitmap` KDoc in `ImageBitmapChess3DSurface.kt` still described the RGBA readback as coming from "the Vulkan renderer's RGBA8Unorm color target". Desktop renders with Filament now, so it's updated to describe `Renderer::readPixels`.

## Heads-up: most of what looked obsolete is already clean on `main`

I checked every file flagged. On the merged `main` (`e43673a`), these are **already free of Vulkan/LWJGL/lavapipe** — #62 removed them:

| File | Status on `main` |
|---|---|
| `gradle/libs.versions.toml` | clean — no `lwjgl`/`vulkan`/`shaderc`/`joml`/`jgltf` entries |
| `.github/workflows/android-tests.yml` | clean — installs `cmake`/`mesa`/Filament, no `mesa-vulkan-drivers`/lavapipe |
| `README.md` | clean — the architecture diagram shows `DesktopFilamentChessRenderer (Filament / native C++)` |
| `THIRD_PARTY_NOTICES.md` | clean — only `vkChess` remains, which is the **chess model's** provenance/attribution, not a renderer dep |

If you're still seeing Vulkan there locally, your checkout is likely behind `origin/main` (it was at `bd32720` for me until I pulled the #62 merge) — a `git pull` should clear it.

## One judgment call left for you

`CLAUDE.md` (and `AGENTS.md`, which symlinks to it) has one remaining Vulkan mention — the **Android** backend note: *"Materia and a raw NDK Vulkan renderer were evaluated and rejected."* I left it because it's accurate historical context for why Android uses SceneView (and the rationale is in the linked `docs/plans/`), not an obsolete desktop claim. Say the word if you'd rather I drop that line too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
