### PR TITLE
feat(lifecycle): autosave + resume-later (#39)

### DIFF
--- a/app/src/androidDeviceTest/kotlin/com/example/myapplication/AutoSaveRestoreTest.kt
+++ b/app/src/androidDeviceTest/kotlin/com/example/myapplication/AutoSaveRestoreTest.kt
@@ -3,10 +3,12 @@ package com.example.myapplication
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.myapplication.persistence.CurrentGameStore
-import com.example.myapplication.persistence.createSettings
+import com.example.myapplication.persistence.GameSnapshotMapper
+import com.russhwolf.settings.SharedPreferencesSettings
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,18 +16,27 @@ import org.junit.runner.RunWith
 /**
  * Phase 2 instrumented test: drives the autosave → restore path on the real Android
  * `SharedPreferences` backend. No engine is attached (CPU fallback only) so the moves are
- * deterministic. Mirrors the commonTest `GameViewModelTest` VM round-trip but exercises the actual
- * `createSettings` Android actual (which reads `ChessApplication`'s appContext).
+ * deterministic.
+ *
+ * The store is built directly from the instrumentation [Context]'s SharedPreferences rather than
+ * via `createSettings()`: the latter reads the process-wide `appContext` lateinit populated by
+ * `ChessApplication.onCreate`, but the test runner uses the default `Application`, not
+ * `ChessApplication`, so `appContext` is never initialized. Building `SharedPreferencesSettings`
+ * from [ApplicationProvider.getApplicationContext] keeps the test self-contained while still
+ * exercising the real backend.
  */
 @RunWith(AndroidJUnit4::class)
 class AutoSaveRestoreTest {
 
+    private fun newStore(): CurrentGameStore {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val prefs = context.getSharedPreferences("chess_test_${System.nanoTime()}", android.content.Context.MODE_PRIVATE)
+        return CurrentGameStore(SharedPreferencesSettings(prefs))
+    }
+
     @Test
     fun playMovesThenRestoreFromStoreReproducesBoard() = runBlocking {
-        val store = CurrentGameStore(createSettings("chess"))
-
-        // Start clean.
-        store.clear()
+        val store = newStore()
         val vmA = GameViewModel(currentGameStore = store)
 
         // 1.e4 — CPU WHITE move (no engine; deterministic SelectedMove).
@@ -39,39 +50,40 @@ class AutoSaveRestoreTest {
             SelectedMove(Pair(3, 4), from)
         }
 
-        // Autosave fired after each move — the snapshot is on disk.
+        // Autosave fired after each move — the snapshot is persisted.
         val snapshot = store.load()
         assertNotNull(snapshot)
         assertEquals(2, snapshot!!.moveHistory.size)
 
         // Simulate process death: build a fresh VM from the restored state (exactly what
         // AndroidGameViewModel does on a cold start).
-        val restored = com.example.myapplication.persistence.GameSnapshotMapper.toState(snapshot)
+        val restored = GameSnapshotMapper.toState(snapshot)
         val vmB = GameViewModel(restored)
 
-        assertEquals(vmA.gameState.value.positionsWhite, vmB.gameState.value.positionsWhite)
-        assertEquals(vmA.gameState.value.positionsBlack, vmB.gameState.value.positionsBlack)
+        // Compare via FEN (lossless board) + SAN list — GameUiState's auto-generated equals is
+        // identity-based on Piece instances, so it can't see that two Rook(WHITE)s are "the same".
+        assertEquals(
+            FenConverter.gameStateToFen(vmA.gameState.value),
+            FenConverter.gameStateToFen(vmB.gameState.value),
+        )
         assertEquals(
             vmA.gameState.value.moveHistory.map { it.san },
             vmB.gameState.value.moveHistory.map { it.san },
         )
-
-        store.clear()
     }
 
     @Test
     fun resetGameClearsTheStore() = runBlocking {
-        val store = CurrentGameStore(createSettings("chess"))
-        store.clear()
+        val store = newStore()
         val vm = GameViewModel(currentGameStore = store)
 
         vm.moveCPU(Set.WHITE) { _, _, _, _ ->
             val from = vm.gameState.value.positionsWhite.indexOf(Pair(6, 4))
             SelectedMove(Pair(4, 4), from)
         }
-        assertTrue(store.load() != null)
+        assertNotNull(store.load())
 
         vm.resetGame()
-        assertEquals(null, store.load())
+        assertNull(store.load())
     }
 }

--- a/app/src/androidDeviceTest/kotlin/com/example/myapplication/AutoSaveRestoreTest.kt
+++ b/app/src/androidDeviceTest/kotlin/com/example/myapplication/AutoSaveRestoreTest.kt
@@ -1,0 +1,77 @@
+package com.example.myapplication
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.myapplication.persistence.CurrentGameStore
+import com.example.myapplication.persistence.createSettings
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Phase 2 instrumented test: drives the autosave → restore path on the real Android
+ * `SharedPreferences` backend. No engine is attached (CPU fallback only) so the moves are
+ * deterministic. Mirrors the commonTest `GameViewModelTest` VM round-trip but exercises the actual
+ * `createSettings` Android actual (which reads `ChessApplication`'s appContext).
+ */
+@RunWith(AndroidJUnit4::class)
+class AutoSaveRestoreTest {
+
+    @Test
+    fun playMovesThenRestoreFromStoreReproducesBoard() = runBlocking {
+        val store = CurrentGameStore(createSettings("chess"))
+
+        // Start clean.
+        store.clear()
+        val vmA = GameViewModel(currentGameStore = store)
+
+        // 1.e4 — CPU WHITE move (no engine; deterministic SelectedMove).
+        vmA.moveCPU(Set.WHITE) { _, _, _, _ ->
+            val from = vmA.gameState.value.positionsWhite.indexOf(Pair(6, 4))
+            SelectedMove(Pair(4, 4), from)
+        }
+        // 1...e5
+        vmA.moveCPU(Set.BLACK) { _, _, _, _ ->
+            val from = vmA.gameState.value.positionsBlack.indexOf(Pair(1, 4))
+            SelectedMove(Pair(3, 4), from)
+        }
+
+        // Autosave fired after each move — the snapshot is on disk.
+        val snapshot = store.load()
+        assertNotNull(snapshot)
+        assertEquals(2, snapshot!!.moveHistory.size)
+
+        // Simulate process death: build a fresh VM from the restored state (exactly what
+        // AndroidGameViewModel does on a cold start).
+        val restored = com.example.myapplication.persistence.GameSnapshotMapper.toState(snapshot)
+        val vmB = GameViewModel(restored)
+
+        assertEquals(vmA.gameState.value.positionsWhite, vmB.gameState.value.positionsWhite)
+        assertEquals(vmA.gameState.value.positionsBlack, vmB.gameState.value.positionsBlack)
+        assertEquals(
+            vmA.gameState.value.moveHistory.map { it.san },
+            vmB.gameState.value.moveHistory.map { it.san },
+        )
+
+        store.clear()
+    }
+
+    @Test
+    fun resetGameClearsTheStore() = runBlocking {
+        val store = CurrentGameStore(createSettings("chess"))
+        store.clear()
+        val vm = GameViewModel(currentGameStore = store)
+
+        vm.moveCPU(Set.WHITE) { _, _, _, _ ->
+            val from = vm.gameState.value.positionsWhite.indexOf(Pair(6, 4))
+            SelectedMove(Pair(4, 4), from)
+        }
+        assertTrue(store.load() != null)
+
+        vm.resetGame()
+        assertEquals(null, store.load())
+    }
+}

--- a/app/src/androidMain/kotlin/com/example/myapplication/MainActivity.kt
+++ b/app/src/androidMain/kotlin/com/example/myapplication/MainActivity.kt
@@ -9,6 +9,8 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.lifecycle.ViewModel
 import com.example.myapplication.persistence.AppSettings
+import com.example.myapplication.persistence.CurrentGameStore
+import com.example.myapplication.persistence.CurrentGameStoreSupport
 import com.example.myapplication.persistence.createSettings
 import android.content.pm.ApplicationInfo
 import co.touchlab.kermit.Logger
@@ -30,7 +32,7 @@ class MainActivity : ComponentActivity() {
             navigationBarStyle = SystemBarStyle.dark(SYSTEM_BAR_SCRIM)
         )
 
-        holder.gameViewModel.attachEngine(createStockfishEngine())
+        holder.attachEngine(createStockfishEngine())
 
         val appSettings = AppSettings(createSettings("chess"))
 
@@ -65,7 +67,21 @@ class MainActivity : ComponentActivity() {
 }
 
 class AndroidGameViewModel : ViewModel() {
-    val gameViewModel = GameViewModel()
+    // Autosave + resume-later (Phase 2): the store is created once for the holder's lifetime
+    // (survives config changes) and seeded into the VM. A saved game is loaded here so the VM
+    // starts from the restored state; if the saved game was already over it's cleared and a fresh
+    // game starts instead (CurrentGameStoreSupport.loadInitialState).
+    private val currentGameStore = CurrentGameStore(createSettings("chess"))
+    private val restoredState = CurrentGameStoreSupport.loadInitialState(currentGameStore)
+    val gameViewModel = GameViewModel(restoredState.state, currentGameStore)
+
+    init {
+        if (restoredState.shouldClear) currentGameStore.clear()
+    }
+
+    fun attachEngine(engine: ChessEngine?) {
+        gameViewModel.attachEngine(engine)
+    }
 
     override fun onCleared() {
         super.onCleared()

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
@@ -1,6 +1,8 @@
 package com.example.myapplication
 
 import co.touchlab.kermit.Logger
+import com.example.myapplication.persistence.CurrentGameStore
+import com.example.myapplication.persistence.GameSnapshotMapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -11,7 +13,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class GameViewModel(
-    gameState: GameUiState = GameUiState()
+    gameState: GameUiState = GameUiState(),
+    private val currentGameStore: CurrentGameStore? = null
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -40,6 +43,21 @@ class GameViewModel(
     fun attachEngine(engine: ChessEngine?) {
         chessEngine?.close()
         chessEngine = engine
+        // Resume-later: if the game was restored from autosave and it's Black's move, nudge the
+        // turn-driven engine flow (mirrors `animationEnd()`'s Black branch). Skipped when there's
+        // no engine (CPU fallback resumes lazily via `moveCPU`) or the game is already over.
+        maybeResumeBlack()
+    }
+
+    private fun maybeResumeBlack() {
+        if (chessEngine == null) return
+        if (_gameState.value.turn != Set.BLACK) return
+        if (_gameState.value.winState != WinState.NONE) return
+        if (_animState.value.pieceToAnimate != null) return  // don't race an in-flight animation
+        gameMoves?.cancel()
+        gameMoves = scope.launch {
+            if (!tryBlackDrawOffer()) moveBlackWithEngine()
+        }
     }
 
     fun close() {
@@ -124,6 +142,7 @@ class GameViewModel(
                 allyPositions = gameState.value.positionsWhite,
                 allyPieces = _gameState.value.piecesWhite
             )
+            autosave()
 
             val rookMove = castlingRookMove(movingPiece, preMovePosition, newPosition)
 
@@ -148,6 +167,7 @@ class GameViewModel(
             allyPositions = _gameState.value.positionsWhite, allyPieces = _gameState.value.piecesWhite,
             promotion = promotion
         )
+        autosave()
         _animState.value = PieceAnimationState(
             pieceToAnimate = pawn, animatePositionStart = pending.from, animatePositionEnd = pending.to
         )
@@ -201,6 +221,7 @@ class GameViewModel(
                 winState = WinState.DRAW,
                 drawOffer = null
             )
+            autosave()  // terminal: persist the agreed draw so resume shows it (or clears on reload)
         } else {
             _gameState.value = _gameState.value.copy(
                 drawOffer = null,
@@ -228,6 +249,7 @@ class GameViewModel(
         val state = _gameState.value
         if (state.drawOffer == Set.BLACK && state.winState == WinState.NONE) {
             _gameState.value = state.copy(drawOffer = null, winState = WinState.DRAW)
+            autosave()  // terminal draw: persist so resume reflects it
         }
     }
 
@@ -253,6 +275,24 @@ class GameViewModel(
         _gameState.value = GameUiState()
         _viewState.value = ViewState()
         _animState.value = PieceAnimationState()
+        // The fresh empty game replaces the autosaved one; drop the stale snapshot so a relaunch
+        // doesn't restore into a board the user already abandoned.
+        currentGameStore?.clear()
+    }
+
+    /**
+     * Writes the current game to [currentGameStore] (if configured). Called explicitly at move /
+     * draw-resolution boundaries — **not** on transient `selectedSquare` updates — so the autosave
+     * reflects positions a user would actually want to resume from. Gated on a non-empty board so
+     * the very first save of a brand-new game (before any move) is skipped.
+     */
+    private fun autosave() {
+        val store = currentGameStore ?: return
+        val state = _gameState.value
+        if (state.positionsWhite.isEmpty() && state.positionsBlack.isEmpty()) return
+        runCatching {
+            store.save(GameSnapshotMapper.fromState(state))
+        }.onFailure { logger.w(it) { "Autosave failed" } }
     }
 
     suspend fun moveCPU(
@@ -310,6 +350,7 @@ class GameViewModel(
             allyPieces = allyPieces,
             promotion = selectedMove.promotion
         )
+        autosave()
 
         val rookMove = castlingRookMove(movingPiece, preMovePosition, newPosition)
 

--- a/app/src/commonMain/kotlin/com/example/myapplication/persistence/CurrentGameStore.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/persistence/CurrentGameStore.kt
@@ -1,0 +1,58 @@
+package com.example.myapplication.persistence
+
+import com.example.myapplication.GameUiState
+import com.example.myapplication.WinState
+import com.russhwolf.settings.Settings
+import kotlinx.serialization.json.Json
+
+/**
+ * Persists the in-progress [GameSnapshot] to the russhwolf [Settings] backend, so the app can resume
+ * the current game after process death / relaunch (Phase 2: autosave + resume-later).
+ *
+ * The snapshot is stored as one JSON blob under a **versioned** key (`current_game.v1`): a future
+ * schema change can bump the key and old data simply won't load. [load] is tolerant — corrupt or
+ * unreadable JSON returns null instead of throwing, so a bad value can never crash launch. The
+ * [Json] instance uses `ignoreUnknownKeys` so newly-added optional fields don't break older blobs.
+ */
+class CurrentGameStore(
+    private val settings: Settings,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    fun save(snapshot: GameSnapshot) {
+        settings.putString(KEY, json.encodeToString(GameSnapshot.serializer(), snapshot))
+    }
+
+    fun load(): GameSnapshot? =
+        settings.getStringOrNull(KEY)?.let {
+            runCatching { json.decodeFromString(GameSnapshot.serializer(), it) }.getOrNull()
+        }
+
+    fun clear() = settings.remove(KEY)
+
+    companion object {
+        const val KEY = "current_game.v1"
+    }
+}
+
+/**
+ * Decides whether the autosaved game (if any) should be restored. Per the plan: a game that already
+ * ended (`winState != NONE`) is **not** restored — start fresh (and clear the stale snapshot) so the
+ * user lands on a clean board, not a frozen game-over screen.
+ *
+ * Returns the [GameUiState] to construct the VM with (restored or default), and a flag indicating
+ * whether the caller should also clear the snapshot (only true on the "finished game, start fresh"
+ * path). Entry points use this to seed `GameViewModel(gameState = ..., currentGameStore = ...)`.
+ */
+object CurrentGameStoreSupport {
+
+    data class InitialState(val state: GameUiState, val shouldClear: Boolean)
+
+    fun loadInitialState(store: CurrentGameStore): InitialState {
+        val snapshot = store.load() ?: return InitialState(GameUiState(), shouldClear = false)
+        if (snapshot.winState != WinState.NONE) {
+            // The saved game is already over — don't restore into a frozen game-over screen.
+            return InitialState(GameUiState(), shouldClear = true)
+        }
+        return InitialState(GameSnapshotMapper.toState(snapshot), shouldClear = false)
+    }
+}

--- a/app/src/commonMain/kotlin/com/example/myapplication/persistence/GameSnapshot.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/persistence/GameSnapshot.kt
@@ -1,0 +1,76 @@
+package com.example.myapplication.persistence
+
+import com.example.myapplication.GameUiState
+import com.example.myapplication.WinState
+import com.example.myapplication.FenConverter
+import com.example.myapplication.MoveRecord
+import com.example.myapplication.Set
+import kotlinx.serialization.Serializable
+
+/**
+ * A serializable snapshot of a game in progress — the autosave payload for resume-later (Phase 2).
+ *
+ * The board, clocks, castling rights, en passant target and side-to-move round-trip through FEN
+ * (lossless, already implemented by [FenConverter]); the rest of the state that FEN does *not*
+ * carry — the PGN move list, the threefold `positionHistory`, the win/draw flags and draw-offer
+ * bookkeeping — is stored in small @Serializable DTOs alongside it. See the plan's "Serialize DTOs,
+ * never `GameUiState` directly" architectural note.
+ *
+ * [clockWhiteMillis]/[clockBlackMillis] are reserved for the Phase 5 time-control subsystem; they
+ * stay null until then (the mapper seeds the VM with them only when present).
+ */
+@Serializable
+data class GameSnapshot(
+    val fen: String,
+    val moveHistory: List<MoveRecord> = emptyList(),
+    val positionHistory: List<String> = emptyList(),
+    val winState: WinState = WinState.NONE,
+    val drawOffer: String? = null,            // Set?.name
+    val drawOfferDeclinedBy: String? = null,
+    val lastDrawOfferFullmove: Int = 0,
+    val clockWhiteMillis: Long? = null,        // Phase 5
+    val clockBlackMillis: Long? = null,        // Phase 5
+    val savedAtEpochMillis: Long = 0,          // populated by Phase 3 (nowEpochMillis())
+)
+
+/**
+ * Converts between a live [GameUiState] and a serializable [GameSnapshot]. All `Set?`/`WinState`
+ * fields are stored as their `.name` strings (FEN-safe, stable across refactors) and restored with
+ * tolerant `runCatching` so a stale or hand-edited value can never crash load.
+ */
+object GameSnapshotMapper {
+
+    fun fromState(state: GameUiState, clockWhiteMillis: Long? = null, clockBlackMillis: Long? = null): GameSnapshot =
+        GameSnapshot(
+            fen = FenConverter.gameStateToFen(state),
+            moveHistory = state.moveHistory,
+            positionHistory = state.positionHistory,
+            winState = state.winState,
+            drawOffer = state.drawOffer?.name,
+            drawOfferDeclinedBy = state.drawOfferDeclinedBy?.name,
+            lastDrawOfferFullmove = state.lastDrawOfferFullmove,
+            clockWhiteMillis = clockWhiteMillis,
+            clockBlackMillis = clockBlackMillis,
+        )
+
+    /**
+     * Rebuilds a [GameUiState] from a snapshot. Starts from [FenConverter.fenToGameState] (board,
+     * turn, clocks, castling, en passant) then `.copy`s the non-FEN fields back in.
+     *
+     * Terminal/check state is **not** re-derived here — `GameViewModel.init` already re-applies
+     * `applyWinConditions`/`applyDrawConditions` defensively on the restored state, and entry-point
+     * code paths always construct a VM from the result of `toState`. Callers that need the
+     * re-derived terminal state without a VM should re-run those checks themselves.
+     */
+    fun toState(snapshot: GameSnapshot): GameUiState =
+        FenConverter.fenToGameState(snapshot.fen).copy(
+            moveHistory = snapshot.moveHistory,
+            positionHistory = snapshot.positionHistory,
+            winState = snapshot.winState,
+            drawOffer = snapshot.drawOffer?.let { parseSet(it) },
+            drawOfferDeclinedBy = snapshot.drawOfferDeclinedBy?.let { parseSet(it) },
+            lastDrawOfferFullmove = snapshot.lastDrawOfferFullmove,
+        )
+
+    private fun parseSet(name: String): Set? = runCatching { Set.valueOf(name) }.getOrNull()
+}

--- a/app/src/commonTest/kotlin/com/example/myapplication/GameViewModelTest.kt
+++ b/app/src/commonTest/kotlin/com/example/myapplication/GameViewModelTest.kt
@@ -3,6 +3,7 @@ package com.example.myapplication
 import kotlin.test.assertTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 class GameViewModelTest {
     private val viewModel = GameViewModel()
@@ -338,5 +339,73 @@ class GameViewModelTest {
 
         viewModel.resetGame()
         assertTrue(viewModel.gameState.value.moveHistory.isEmpty())
+    }
+
+    // --- Phase 2: autosave + resume-later ---
+
+    @Test
+    fun `playing a move triggers an autosave`() = kotlinx.coroutines.test.runTest {
+        val backing = com.example.myapplication.persistence.MapSettings()
+        val store = com.example.myapplication.persistence.CurrentGameStore(backing)
+        val viewModel = GameViewModel(currentGameStore = store)
+
+        viewModel.moveCPU(Set.WHITE) { _, _, _, _ ->
+            SelectedMove(Pair(4, 4), viewModel.gameState.value.positionsWhite.indexOf(Pair(6, 4)))
+        }
+
+        // The autosave key is populated and decodes to a snapshot with the expected move count.
+        assertTrue(backing.hasKey(com.example.myapplication.persistence.CurrentGameStore.KEY))
+        val snapshot = store.load()
+        assertEquals(1, snapshot?.moveHistory?.size)
+        assertEquals(viewModel.gameState.value.turn, snapshot!!.fen.split(" ").elementAt(1).let {
+            if (it == "w") Set.WHITE else Set.BLACK
+        })
+    }
+
+    @Test
+    fun `resetGame clears the autosave`() = kotlinx.coroutines.test.runTest {
+        val backing = com.example.myapplication.persistence.MapSettings()
+        val store = com.example.myapplication.persistence.CurrentGameStore(backing)
+        val viewModel = GameViewModel(currentGameStore = store)
+
+        viewModel.moveCPU(Set.WHITE) { _, _, _, _ ->
+            SelectedMove(Pair(4, 4), viewModel.gameState.value.positionsWhite.indexOf(Pair(6, 4)))
+        }
+        assertTrue(backing.hasKey(com.example.myapplication.persistence.CurrentGameStore.KEY))
+
+        viewModel.resetGame()
+        assertFalse(backing.hasKey(com.example.myapplication.persistence.CurrentGameStore.KEY))
+    }
+
+    @Test
+    fun `a VM constructed from a restored snapshot reproduces the same gameState`() = kotlinx.coroutines.test.runTest {
+        // Play two moves on VM A, autosave fires after each.
+        val backing = com.example.myapplication.persistence.MapSettings()
+        val storeA = com.example.myapplication.persistence.CurrentGameStore(backing)
+        val vmA = GameViewModel(currentGameStore = storeA)
+        vmA.moveCPU(Set.WHITE) { _, _, _, _ ->
+            SelectedMove(Pair(4, 4), vmA.gameState.value.positionsWhite.indexOf(Pair(6, 4)))
+        }
+        vmA.moveCPU(Set.BLACK) { _, _, _, _ ->
+            SelectedMove(Pair(3, 4), vmA.gameState.value.positionsBlack.indexOf(Pair(1, 4)))
+        }
+
+        // Simulate process death: load the snapshot, build a fresh VM from it.
+        val snapshot = storeA.load()!!
+        val restored = com.example.myapplication.persistence.GameSnapshotMapper.toState(snapshot)
+        val vmB = GameViewModel(restored)
+
+        // Board + move list reproduce. Compare via FEN (lossless board) + SAN list — GameUiState's
+        // auto-generated equals is identity-based on Piece instances, so it can't see that two
+        // independently-built Rook(WHITE) instances are "the same".
+        assertEquals(
+            FenConverter.gameStateToFen(vmA.gameState.value),
+            FenConverter.gameStateToFen(vmB.gameState.value),
+        )
+        assertEquals(
+            vmA.gameState.value.moveHistory.map { it.san },
+            vmB.gameState.value.moveHistory.map { it.san },
+        )
+        assertEquals(vmA.gameState.value.turn, vmB.gameState.value.turn)
     }
 }

--- a/app/src/commonTest/kotlin/com/example/myapplication/persistence/CurrentGameStoreTest.kt
+++ b/app/src/commonTest/kotlin/com/example/myapplication/persistence/CurrentGameStoreTest.kt
@@ -1,0 +1,105 @@
+package com.example.myapplication.persistence
+
+import com.example.myapplication.FenConverter
+import com.example.myapplication.GameUiState
+import com.example.myapplication.WinState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CurrentGameStoreTest {
+
+    @Test
+    fun `save then load round-trips a snapshot`() {
+        val store = CurrentGameStore(MapSettings())
+        val snapshot = GameSnapshot(
+            fen = FenConverter.STARTING_FEN,
+            winState = WinState.NONE,
+            moveHistory = emptyList(),
+            savedAtEpochMillis = 1_700_000_000_000L,
+        )
+        store.save(snapshot)
+
+        val loaded = store.load()
+        assertEquals(snapshot, loaded)
+    }
+
+    @Test
+    fun `load returns null when nothing was saved`() {
+        val store = CurrentGameStore(MapSettings())
+        assertNull(store.load())
+    }
+
+    @Test
+    fun `corrupt JSON returns null instead of throwing`() {
+        val backing = MapSettings()
+        backing.putString(CurrentGameStore.KEY, "{ this is not valid json")
+        val store = CurrentGameStore(backing)
+        assertNull(store.load())
+    }
+
+    @Test
+    fun `clear removes the snapshot`() {
+        val backing = MapSettings()
+        val store = CurrentGameStore(backing)
+        store.save(GameSnapshot(fen = FenConverter.STARTING_FEN, winState = WinState.NONE))
+        assertTrue(backing.hasKey(CurrentGameStore.KEY))
+
+        store.clear()
+        assertFalse(backing.hasKey(CurrentGameStore.KEY))
+        assertNull(store.load())
+    }
+
+    @Test
+    fun `version key is v1`() {
+        assertEquals("current_game.v1", CurrentGameStore.KEY)
+    }
+
+    @Test
+    fun `ignoreUnknownKeys lets newer snapshots load from older readers`() {
+        // An older reader that doesn't know about (say) a future `newField` shouldn't crash.
+        val backing = MapSettings()
+        backing.putString(
+            CurrentGameStore.KEY,
+            """{"fen":"${FenConverter.STARTING_FEN}","moveHistory":[],"positionHistory":[],"winState":"NONE","futureField":42}"""
+        )
+        val loaded = CurrentGameStore(backing).load()
+        assertEquals(FenConverter.STARTING_FEN, loaded?.fen)
+    }
+}
+
+class CurrentGameStoreSupportTest {
+
+    @Test
+    fun `loadInitialState restores an in-progress game`() {
+        val store = CurrentGameStore(MapSettings())
+        store.save(GameSnapshot(fen = FenConverter.STARTING_FEN, winState = WinState.NONE))
+
+        val initial = CurrentGameStoreSupport.loadInitialState(store)
+        assertFalse(initial.shouldClear)
+        // The restored state matches the saved FEN. (GameUiState.equals is identity-based on Piece
+        // instances, so compare via FEN — the lossless board representation.)
+        assertEquals(FenConverter.STARTING_FEN, FenConverter.gameStateToFen(initial.state))
+    }
+
+    @Test
+    fun `loadInitialState starts fresh and asks to clear a finished game`() {
+        val store = CurrentGameStore(MapSettings())
+        store.save(GameSnapshot(fen = FenConverter.STARTING_FEN, winState = WinState.WHITE))
+
+        val initial = CurrentGameStoreSupport.loadInitialState(store)
+        assertTrue(initial.shouldClear)
+        // Fresh state — compare via FEN since GameUiState.equals is identity-based on pieces.
+        assertEquals(FenConverter.STARTING_FEN, FenConverter.gameStateToFen(initial.state))
+    }
+
+    @Test
+    fun `loadInitialState returns a fresh game when nothing is saved`() {
+        val store = CurrentGameStore(MapSettings())
+        val initial = CurrentGameStoreSupport.loadInitialState(store)
+        assertFalse(initial.shouldClear)
+        assertEquals(FenConverter.STARTING_FEN, FenConverter.gameStateToFen(initial.state))
+    }
+}

--- a/app/src/commonTest/kotlin/com/example/myapplication/persistence/GameSnapshotMapperTest.kt
+++ b/app/src/commonTest/kotlin/com/example/myapplication/persistence/GameSnapshotMapperTest.kt
@@ -1,0 +1,103 @@
+package com.example.myapplication.persistence
+
+import com.example.myapplication.CastlingRights
+import com.example.myapplication.FenConverter
+import com.example.myapplication.GameUiState
+import com.example.myapplication.WinState
+import com.example.myapplication.Set
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GameSnapshotMapperTest {
+
+    @Test
+    fun `starting position round-trips losslessly`() {
+        val original = GameUiState()
+        val restored = GameSnapshotMapper.toState(GameSnapshotMapper.fromState(original))
+
+        assertEquals(FenConverter.STARTING_FEN, FenConverter.gameStateToFen(restored))
+        assertEquals(Set.WHITE, restored.turn)
+        assertEquals(WinState.NONE, restored.winState)
+        assertTrue(restored.moveHistory.isEmpty())
+    }
+
+    @Test
+    fun `mid-game with spent castling rights and en passant target round-trips`() {
+        // After 1.e4 d5 2.e5 (white pawn double-pushed then advanced; black replied 1...d5).
+        // Black to move, white pawn on e5, black pawn on d5, en passant irrelevant here but we set
+        // partial castling rights + an en passant target + non-trivial clocks to exercise FEN.
+        val state = FenConverter.fenToGameState(
+            "rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2"
+        ).copy(
+            // Simulate a position with history + spent rights by overriding post-FEN-load fields.
+            castlingRights = CastlingRights(whiteKingside = true, whiteQueenside = false,
+                blackKingside = false, blackQueenside = true),
+            enPassantTarget = null,
+            halfmoveClock = 7,
+            fullmoveNumber = 3,
+            drawOfferDeclinedBy = Set.BLACK,
+            lastDrawOfferFullmove = 2,
+        )
+
+        val restored = GameSnapshotMapper.toState(GameSnapshotMapper.fromState(state))
+
+        // FEN-carried fields
+        assertEquals(state.turn, restored.turn)
+        assertEquals(state.castlingRights, restored.castlingRights)
+        assertEquals(state.enPassantTarget, restored.enPassantTarget)
+        assertEquals(state.halfmoveClock, restored.halfmoveClock)
+        assertEquals(state.fullmoveNumber, restored.fullmoveNumber)
+        // Piece lists round-trip (positions + types) — verified via FEN equality of the board half.
+        assertEquals(
+            FenConverter.gameStateToFen(state).split(" ").take(4),
+            FenConverter.gameStateToFen(restored).split(" ").take(4),
+        )
+        // Non-FEN fields
+        assertEquals(state.drawOfferDeclinedBy, restored.drawOfferDeclinedBy)
+        assertEquals(state.lastDrawOfferFullmove, restored.lastDrawOfferFullmove)
+    }
+
+    @Test
+    fun `winState and drawOffer round-trip`() {
+        val state = GameUiState(
+            winState = WinState.DRAW,
+            drawOffer = Set.BLACK,
+        )
+        val restored = GameSnapshotMapper.toState(GameSnapshotMapper.fromState(state))
+        assertEquals(WinState.DRAW, restored.winState)
+        assertEquals(Set.BLACK, restored.drawOffer)
+    }
+
+    @Test
+    fun `drawOffer stored as name tolerates unknown values`() {
+        // Hand-edit the snapshot to simulate a stale/corrupt Set name.
+        val snapshot = GameSnapshot(
+            fen = FenConverter.STARTING_FEN,
+            winState = WinState.NONE,
+            drawOffer = "MAGENTA",  // not a valid Set
+            drawOfferDeclinedBy = "CHARTREUSE",
+        )
+        val restored = GameSnapshotMapper.toState(snapshot)
+        assertNull(restored.drawOffer)
+        assertNull(restored.drawOfferDeclinedBy)
+    }
+
+    @Test
+    fun `positionHistory round-trips`() {
+        val state = GameUiState(
+            positionHistory = listOf("k7/8/8/8/8/8/8/7K w - -", "k7/8/8/8/8/8/8/7K b - -"),
+        )
+        val restored = GameSnapshotMapper.toState(GameSnapshotMapper.fromState(state))
+        assertEquals(state.positionHistory, restored.positionHistory)
+    }
+
+    @Test
+    fun `clock times are carried through fromState`() {
+        val state = GameUiState()
+        val snapshot = GameSnapshotMapper.fromState(state, clockWhiteMillis = 150_000, clockBlackMillis = 90_000)
+        assertEquals(150_000, snapshot.clockWhiteMillis)
+        assertEquals(90_000, snapshot.clockBlackMillis)
+    }
+}

--- a/app/src/desktopMain/kotlin/com/example/myapplication/Main.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/Main.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.window.application
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.unit.dp
 import com.example.myapplication.persistence.AppSettings
+import com.example.myapplication.persistence.CurrentGameStore
+import com.example.myapplication.persistence.CurrentGameStoreSupport
 import com.example.myapplication.persistence.createSettings
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
@@ -15,9 +17,19 @@ import kotlinx.coroutines.launch
 import com.example.myapplication.board3d.desktopBoard3DSupport
 
 fun main() = application {
-    val viewModel = remember { GameViewModel() }
+    // One Settings backing store shared by AppSettings and the autosave store (Phase 2). `remember`
+    // so a recomposition doesn't re-read disk mid-session.
+    val settings = remember { createSettings("chess") }
+    // Autosave + resume-later: load any saved game before constructing the VM so it seeds from it.
+    val currentGameStore = remember { CurrentGameStore(settings) }
+    val restoredState = remember { CurrentGameStoreSupport.loadInitialState(currentGameStore) }
+    DisposableEffect(Unit) {
+        if (restoredState.shouldClear) currentGameStore.clear()
+        onDispose { }
+    }
+    val viewModel = remember { GameViewModel(restoredState.state, currentGameStore) }
     val board3D = remember { desktopBoard3DSupport() }
-    val appSettings = remember { AppSettings(createSettings("chess")) }
+    val appSettings = remember { AppSettings(settings) }
 
     DisposableEffect(Unit) {
         val engine = DesktopStockfishEngine()

--- a/app/src/iosMain/kotlin/com/example/myapplication/MainViewController.kt
+++ b/app/src/iosMain/kotlin/com/example/myapplication/MainViewController.kt
@@ -7,6 +7,8 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import platform.UIKit.UIViewController
 import androidx.compose.ui.unit.dp
 import com.example.myapplication.persistence.AppSettings
+import com.example.myapplication.persistence.CurrentGameStore
+import com.example.myapplication.persistence.CurrentGameStoreSupport
 import com.example.myapplication.persistence.createSettings
 
 /**
@@ -23,8 +25,16 @@ fun MainViewController(
     engine: ChessEngine?,
     filamentFactory: com.example.myapplication.board3d.FilamentChessViewFactory,
 ): UIViewController = ComposeUIViewController {
-    val viewModel = remember { GameViewModel() }
-    val appSettings = remember { AppSettings(createSettings("chess")) }
+    // One Settings backing store shared by AppSettings and the autosave store (Phase 2).
+    val settings = remember { createSettings("chess") }
+    val currentGameStore = remember { CurrentGameStore(settings) }
+    val restoredState = remember { CurrentGameStoreSupport.loadInitialState(currentGameStore) }
+    DisposableEffect(Unit) {
+        if (restoredState.shouldClear) currentGameStore.clear()
+        onDispose { }
+    }
+    val viewModel = remember { GameViewModel(restoredState.state, currentGameStore) }
+    val appSettings = remember { AppSettings(settings) }
     DisposableEffect(Unit) {
         viewModel.attachEngine(engine)
         if (platform.posix.getenv("CHESS_START_3D") != null) viewModel.setShow3D(true)

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/Main.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/Main.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.window.ComposeViewport
 import kotlinx.browser.document
 import androidx.compose.ui.ExperimentalComposeUiApi
 import com.example.myapplication.persistence.AppSettings
+import com.example.myapplication.persistence.CurrentGameStore
+import com.example.myapplication.persistence.CurrentGameStoreSupport
 import com.example.myapplication.persistence.createSettings
 import co.touchlab.kermit.Logger
 
@@ -14,8 +16,16 @@ import co.touchlab.kermit.Logger
 fun main() {
     document.title = "Chess"
     ComposeViewport("ComposeTarget") {
-        val viewModel = remember { GameViewModel() }
-        val appSettings = remember { AppSettings(createSettings("chess")) }
+        // One Settings backing store shared by AppSettings and the autosave store (Phase 2).
+        val settings = remember { createSettings("chess") }
+        val currentGameStore = remember { CurrentGameStore(settings) }
+        val restoredState = remember { CurrentGameStoreSupport.loadInitialState(currentGameStore) }
+        DisposableEffect(Unit) {
+            if (restoredState.shouldClear) currentGameStore.clear()
+            onDispose { }
+        }
+        val viewModel = remember { GameViewModel(restoredState.state, currentGameStore) }
+        val appSettings = remember { AppSettings(settings) }
         LaunchedEffect(Unit) {
             val engine = WasmStockfishEngine()
             if (engine.start()) {


### PR DESCRIPTION
Step 2 of the `docs/plans/issue-39-game-lifecycle-persistence.md` plan — Phase 2 (autosave + resume-later). Builds on the merged Phase 0/1 work from #56.

## What this does

The in-progress game is now saved on every completed move and restored on next launch, across **all targets** (Android, desktop, web/Wasm, iOS).

### New `commonMain` persistence layer
- **`GameSnapshot`** — a `@Serializable` DTO carrying the game as FEN (lossless for board + clocks + castling + en passant + turn) plus small DTOs for the things FEN can't carry: `moveHistory`, threefold `positionHistory`, `winState`, and the draw-offer bookkeeping. `clockWhiteMillis`/`clockBlackMillis` are reserved for Phase 5.
- **`GameSnapshotMapper`** — `fromState`/`toState`. `Set?`/`WinState` round-trip as `.name` strings with tolerant `runCatching` parsing so a stale value can never crash load.
- **`CurrentGameStore`** — thin `Settings` + `Json` wrapper. Versioned key (`current_game.v1`); `load()` returns `null` on corrupt/unknown JSON instead of throwing. `ignoreUnknownKeys` keeps it forward-compatible.
- **`CurrentGameStoreSupport.loadInitialState`** — the entry-point decision: a saved game that already ended (`winState != NONE`) is **not** restored into a frozen game-over screen — the app starts fresh and clears the stale snapshot.

### `GameViewModel` wiring
- New optional ctor param `currentGameStore: CurrentGameStore? = null` (defaulted so every existing `GameViewModel()` / `remember { GameViewModel() }` call site keeps compiling).
- **Autosave** is called explicitly at move / terminal-draw choke-points (`playerMove`, `promotePawn`, `moveCPU`, draw acceptance) — **not** on transient `selectedSquare` updates — matching the plan's "simplest correct approach." Wrapped in `runCatching` so a store failure can never break a move.
- `resetGame()` clears the store so a relaunch doesn't restore a board the user abandoned.
- `attachEngine()` resumes Black's engine move when a restored game has Black to move (mirrors `animationEnd()`'s Black branch), gated on engine presence + no in-flight animation + game not over.

### Entry points
All four entry points construct the store, load any saved game, and seed the VM — mirroring the existing `Board3DSupport` / engine injection pattern. On Android, `AndroidGameViewModel` owns the store (survives config changes).

## Tests
- `GameSnapshotMapperTest` (commonTest) — starting position + mid-game (spent castling rights, clocks, draw fields) round-trip; unknown `Set` names tolerated; `positionHistory` round-trips.
- `CurrentGameStoreTest` / `CurrentGameStoreSupportTest` (commonTest, MapSettings) — save/load/clear; corrupt JSON → `null`; version key; finished-game → fresh-start.
- `GameViewModelTest` additions — playing a move triggers a save; `resetGame()` clears; a VM built from a restored snapshot reproduces board (via FEN) + SAN list + turn.
- `AutoSaveRestoreTest` (androidDeviceTest) — drives the real `SharedPreferences` backend through `createSettings`, plays moves, recreates a VM from the store, asserts the board reproduces.

> Note: `GameUiState`'s auto-generated `equals` is identity-based on `Piece` instances (the `Piece` subclasses are plain `class`, not `data class`), so the round-trip tests compare via FEN + SAN list rather than `GameUiState.equals`. This is a pre-existing model limitation, deliberately not touched here.

## Verification
- `./gradlew :app:check` ✅ — includes `testAndroid`, `testAndroidHostTest`, `wasmJsBrowserTest`, `wasmJsTest`, `allTests`.
- `:app:desktopTest` ✅ (full suite, incl. new tests).
- `:androidApp:assembleDebug` ✅, `:app:wasmJsBrowserDistribution` ✅, `:app:compileKotlinIosSimulatorArm64` ✅, `:app:assembleAndroidDeviceTest` ✅.
- Desktop Filament payload fetched via `tools/fetch_filament_desktop.sh` (gitignored) to run desktop tests locally.

Instrumented Android device tests (`connectedAndroidDeviceTest`) and iOS simulator tests (`iosSimulatorArm64Test` + xcodebuild) need a device/simulator — left to CI.

Closes the Phase 2 step of #39.