### PR TITLE
feat(lifecycle): game history + save/share PGN (#39)

### DIFF
--- a/app/src/androidDeviceTest/kotlin/com/example/myapplication/SaveGameHistoryTest.kt
+++ b/app/src/androidDeviceTest/kotlin/com/example/myapplication/SaveGameHistoryTest.kt
@@ -1,0 +1,78 @@
+package com.example.myapplication
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.myapplication.persistence.GameHistoryRepository
+import com.example.myapplication.share.PgnSharer
+import com.russhwolf.settings.SharedPreferencesSettings
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Phase 3 instrumented test: the end-to-end Save-game → History flow on the real Android
+ * `SharedPreferences` backend. Forces a finished game (WinState.WHITE, no engine — deterministic),
+ * taps "Save game", navigates to History, asserts one row with the right result, then Delete and
+ * asserts empty. `PgnSharer` is a no-op fake so the Share button is present/clickable without
+ * launching a real chooser.
+ */
+@RunWith(AndroidJUnit4::class)
+class SaveGameHistoryTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val fakeSharer = PgnSharer { _, _ -> /* no-op for tests */ }
+
+    private fun newRepo(): GameHistoryRepository {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val prefs = context.getSharedPreferences("chess_history_test_${System.nanoTime()}", android.content.Context.MODE_PRIVATE)
+        return GameHistoryRepository(SharedPreferencesSettings(prefs))
+    }
+
+    @Test
+    fun saveGameAppearsInHistoryAndCanBeDeleted() {
+        val repo = newRepo()
+        val viewModel = GameViewModel(GameUiState(winState = WinState.WHITE))
+
+        // Render the game screen with the game-over popup, the history repo, and the fake sharer.
+        composeTestRule.setContent {
+            GameScreen(
+                windowSize = WindowWidthSizeClass.Medium,
+                viewModel = viewModel,
+                gameHistory = repo,
+                pgnSharer = fakeSharer,
+            )
+        }
+
+        // The game-over popup is showing. Tap "Save game".
+        composeTestRule.onNodeWithTag("save_game_button").performClick()
+        composeTestRule.waitForIdle()
+        // One saved game with the right result.
+        assertEquals(1, repo.games.value.size)
+        assertEquals("1-0", repo.games.value.first().result)
+
+        // Open the History screen directly (bypassing AppRoot nav for test isolation).
+        composeTestRule.setContent {
+            GameHistoryScreen(gameHistory = repo, pgnSharer = fakeSharer, onBack = {})
+        }
+        composeTestRule.waitForIdle()
+
+        // The saved row is present.
+        composeTestRule.onNodeWithText("Result: 1-0", substring = true).assertIsDisplayed()
+
+        // Delete it.
+        composeTestRule.onNodeWithTag("history_delete_${repo.games.value.first().id}").performClick()
+        composeTestRule.waitForIdle()
+        assertEquals(0, repo.games.value.size)
+
+        // Empty state now shows.
+        composeTestRule.onNodeWithTag("history_empty").assertIsDisplayed()
+    }
+}

--- a/app/src/androidDeviceTest/kotlin/com/example/myapplication/SaveGameHistoryTest.kt
+++ b/app/src/androidDeviceTest/kotlin/com/example/myapplication/SaveGameHistoryTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.myapplication.persistence.GameActions
 import com.example.myapplication.persistence.GameHistoryRepository
 import com.example.myapplication.share.PgnSharer
 import com.russhwolf.settings.SharedPreferencesSettings
@@ -16,11 +17,13 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Phase 3 instrumented test: the end-to-end Save-game → History flow on the real Android
- * `SharedPreferences` backend. Forces a finished game (WinState.WHITE, no engine — deterministic),
- * taps "Save game", navigates to History, asserts one row with the right result, then Delete and
- * asserts empty. `PgnSharer` is a no-op fake so the Share button is present/clickable without
- * launching a real chooser.
+ * Phase 3 instrumented tests for the Save-game → History flow on the real Android
+ * `SharedPreferences` backend. `PgnSharer` is a no-op fake so the Share button is present/clickable
+ * without launching a real chooser.
+ *
+ * Split into two tests because a Compose `createComposeRule` binds one `setContent` to its host
+ * Activity for the test's lifetime — calling `setContent` twice ("Activity has already set content")
+ * is illegal. Each test renders exactly one screen.
  */
 @RunWith(AndroidJUnit4::class)
 class SaveGameHistoryTest {
@@ -37,11 +40,10 @@ class SaveGameHistoryTest {
     }
 
     @Test
-    fun saveGameAppearsInHistoryAndCanBeDeleted() {
+    fun tappingSaveGameButtonAddsTheFinishedGameToTheRepository() {
         val repo = newRepo()
         val viewModel = GameViewModel(GameUiState(winState = WinState.WHITE))
 
-        // Render the game screen with the game-over popup, the history repo, and the fake sharer.
         composeTestRule.setContent {
             GameScreen(
                 windowSize = WindowWidthSizeClass.Medium,
@@ -54,11 +56,20 @@ class SaveGameHistoryTest {
         // The game-over popup is showing. Tap "Save game".
         composeTestRule.onNodeWithTag("save_game_button").performClick()
         composeTestRule.waitForIdle()
+
         // One saved game with the right result.
         assertEquals(1, repo.games.value.size)
         assertEquals("1-0", repo.games.value.first().result)
+    }
 
-        // Open the History screen directly (bypassing AppRoot nav for test isolation).
+    @Test
+    fun savedGameAppearsInHistoryAndCanBeDeleted() {
+        val repo = newRepo()
+        // Seed the repo directly (no GameScreen) so this test has its own single setContent.
+        val finished = GameUiState(winState = WinState.WHITE)
+        val saved = GameActions.toSavedGame(finished, engineAttached = true, savedAtEpochMillis = 1_700_000_000_000L)
+        repo.add(saved)
+
         composeTestRule.setContent {
             GameHistoryScreen(gameHistory = repo, pgnSharer = fakeSharer, onBack = {})
         }
@@ -68,7 +79,7 @@ class SaveGameHistoryTest {
         composeTestRule.onNodeWithText("Result: 1-0", substring = true).assertIsDisplayed()
 
         // Delete it.
-        composeTestRule.onNodeWithTag("history_delete_${repo.games.value.first().id}").performClick()
+        composeTestRule.onNodeWithTag("history_delete_${saved.id}").performClick()
         composeTestRule.waitForIdle()
         assertEquals(0, repo.games.value.size)
 

--- a/app/src/androidMain/kotlin/com/example/myapplication/MainActivity.kt
+++ b/app/src/androidMain/kotlin/com/example/myapplication/MainActivity.kt
@@ -11,7 +11,9 @@ import androidx.lifecycle.ViewModel
 import com.example.myapplication.persistence.AppSettings
 import com.example.myapplication.persistence.CurrentGameStore
 import com.example.myapplication.persistence.CurrentGameStoreSupport
+import com.example.myapplication.persistence.GameHistoryRepository
 import com.example.myapplication.persistence.createSettings
+import com.example.myapplication.share.androidPgnSharer
 import android.content.pm.ApplicationInfo
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
@@ -35,12 +37,16 @@ class MainActivity : ComponentActivity() {
         holder.attachEngine(createStockfishEngine())
 
         val appSettings = AppSettings(createSettings("chess"))
+        // PgnSharer needs the host Activity (for ACTION_SEND), so it's built here, not in the holder.
+        val pgnSharer = androidPgnSharer(this)
 
         setContent {
             AppRoot(
                 viewModel = holder.gameViewModel,
                 settings = appSettings,
-                board3D = androidx.compose.runtime.remember { com.example.myapplication.board3d.androidBoard3DSupport() }
+                board3D = androidx.compose.runtime.remember { com.example.myapplication.board3d.androidBoard3DSupport() },
+                gameHistory = holder.gameHistory,
+                pgnSharer = pgnSharer,
             )
         }
     }
@@ -71,9 +77,14 @@ class AndroidGameViewModel : ViewModel() {
     // (survives config changes) and seeded into the VM. A saved game is loaded here so the VM
     // starts from the restored state; if the saved game was already over it's cleared and a fresh
     // game starts instead (CurrentGameStoreSupport.loadInitialState).
-    private val currentGameStore = CurrentGameStore(createSettings("chess"))
+    private val settings = createSettings("chess")
+    private val currentGameStore = CurrentGameStore(settings)
     private val restoredState = CurrentGameStoreSupport.loadInitialState(currentGameStore)
     val gameViewModel = GameViewModel(restoredState.state, currentGameStore)
+
+    // Phase 3: saved-games history lives on the same Settings backing store, owned by the holder so
+    // it survives config changes (and is observed by the History screen across recompositions).
+    val gameHistory = GameHistoryRepository(settings)
 
     init {
         if (restoredState.shouldClear) currentGameStore.clear()

--- a/app/src/androidMain/kotlin/com/example/myapplication/share/PgnSharer.android.kt
+++ b/app/src/androidMain/kotlin/com/example/myapplication/share/PgnSharer.android.kt
@@ -1,0 +1,24 @@
+package com.example.myapplication.share
+
+import android.app.Activity
+import android.content.Intent
+
+/**
+ * Android [PgnSharer]. Uses `ACTION_SEND` with `EXTRA_TEXT = pgn` and `type = "text/plain"` — the
+ * no-manifest-changes fallback the plan allows (FileProvider for a real `.pgn` attachment is a
+ * future enhancement; the PGN as text is universally pasteable into lichess/etc.). Must be given the
+ * host [Activity] (so `startActivity` runs on the right task), constructed at `MainActivity.onCreate`.
+ */
+class AndroidPgnSharer(private val activity: Activity) : PgnSharer {
+    override fun share(pgn: String, suggestedFileName: String) {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_SUBJECT, suggestedFileName)
+            putExtra(Intent.EXTRA_TEXT, pgn)
+        }
+        activity.startActivity(Intent.createChooser(intent, "Share PGN"))
+    }
+}
+
+/** Factory mirroring `androidBoard3DSupport()` — constructed at the Android entry point. */
+fun androidPgnSharer(activity: Activity): PgnSharer = AndroidPgnSharer(activity)

--- a/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
@@ -90,6 +90,7 @@ fun AppRoot(
 internal fun SubScreenScaffold(
     title: String,
     onBack: () -> Unit,
+    scrollable: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     Scaffold(
@@ -104,11 +105,12 @@ internal fun SubScreenScaffold(
             )
         }
     ) { padding ->
+        val scrollState = rememberScrollState()
         Column(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .verticalScroll(rememberScrollState()),
+                .then(if (scrollable) Modifier.verticalScroll(scrollState) else Modifier),
             verticalArrangement = Arrangement.spacedBy(12.dp),
             horizontalAlignment = Alignment.Start,
         ) { content() }

--- a/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
@@ -27,7 +27,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.example.myapplication.board3d.Board3DSupport
 import com.example.myapplication.persistence.AppSettings
+import com.example.myapplication.persistence.GameHistoryRepository
 import com.example.myapplication.persistence.LocalAppSettings
+import com.example.myapplication.share.PgnSharer
 import com.example.myapplication.ui.theme.MyApplicationTheme
 
 /**
@@ -46,6 +48,8 @@ fun AppRoot(
     viewModel: GameViewModel,
     settings: AppSettings,
     board3D: Board3DSupport? = null,
+    gameHistory: GameHistoryRepository? = null,
+    pgnSharer: PgnSharer? = null,
     switchTopPadding: Dp = 8.dp,
 ) {
     CompositionLocalProvider(LocalAppSettings provides settings) {
@@ -57,26 +61,26 @@ fun AppRoot(
                 Screen.GAME -> ChessApp(
                     viewModel = viewModel,
                     board3D = board3D,
+                    gameHistory = gameHistory,
+                    pgnSharer = pgnSharer,
                     switchTopPadding = switchTopPadding,
                     onOpenHistory = { screen = Screen.HISTORY },
                     onOpenSettings = { screen = Screen.SETTINGS },
                 )
-                Screen.HISTORY -> GameHistoryScreenPlaceholder(onBack = { screen = Screen.GAME })
+                Screen.HISTORY -> if (gameHistory != null) {
+                    GameHistoryScreen(
+                        gameHistory = gameHistory,
+                        pgnSharer = pgnSharer,
+                        onBack = { screen = Screen.GAME },
+                    )
+                } else {
+                    SubScreenScaffold(title = "Game History", onBack = { screen = Screen.GAME }) {
+                        Text("Game history is unavailable.")
+                    }
+                }
                 Screen.SETTINGS -> SettingsScreen(onBack = { screen = Screen.GAME })
             }
         }
-    }
-}
-
-/**
- * Placeholder for the Game History screen (Phase 3). Exists now so [AppRoot]'s `when` is total and
- * the History entry button on `GameScreen` has somewhere meaningful to navigate.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun GameHistoryScreenPlaceholder(onBack: () -> Unit) {
-    SubScreenScaffold(title = "Game History", onBack = onBack) {
-        Text("Saved games will appear here.")
     }
 }
 

--- a/app/src/commonMain/kotlin/com/example/myapplication/ChessApp.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/ChessApp.kt
@@ -11,12 +11,16 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 import com.example.myapplication.board3d.Board3DSupport
+import com.example.myapplication.persistence.GameHistoryRepository
+import com.example.myapplication.share.PgnSharer
 
 @Composable
 fun ChessApp(
     viewModel: GameViewModel,
     modifier: Modifier = Modifier,
     board3D: Board3DSupport? = null,
+    gameHistory: GameHistoryRepository? = null,
+    pgnSharer: PgnSharer? = null,
     switchTopPadding: Dp = 8.dp,
     onOpenHistory: () -> Unit = {},
     onOpenSettings: () -> Unit = {},
@@ -35,6 +39,8 @@ fun ChessApp(
                 windowSize = windowSize,
                 viewModel = viewModel,
                 board3D = board3D,
+                gameHistory = gameHistory,
+                pgnSharer = pgnSharer,
                 switchTopPadding = switchTopPadding,
                 onOpenHistory = onOpenHistory,
                 onOpenSettings = onOpenSettings,

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameHistoryScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameHistoryScreen.kt
@@ -1,0 +1,199 @@
+package com.example.myapplication
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.myapplication.persistence.GameHistoryRepository
+import com.example.myapplication.persistence.SavedGame
+import com.example.myapplication.share.PgnSharer
+
+/**
+ * Lists saved games (newest first) from [gameHistory]. Tapping a row opens an inline detail view
+ * with the full PGN (selectable) and **Share** / **Delete** actions. Empty state when no games.
+ *
+ * Reached from [AppRoot] via `Screen.HISTORY`. The detail view is a local `selectedGame` state
+ * rather than a new [Screen] value to keep history navigation shallow.
+ */
+@Composable
+fun GameHistoryScreen(
+    gameHistory: GameHistoryRepository,
+    pgnSharer: PgnSharer? = null,
+    onBack: () -> Unit,
+) {
+    val games by gameHistory.games.collectAsState()
+    var selectedGame by remember { mutableStateOf<SavedGame?>(null) }
+
+    SubScreenScaffold(title = "Game History", onBack = onBack) {
+        val current = selectedGame
+        if (current == null) {
+            GameHistoryList(
+                games = games,
+                pgnSharer = pgnSharer,
+                onOpen = { selectedGame = it },
+                onDelete = { gameHistory.delete(it.id) },
+            )
+        } else {
+            GameHistoryDetail(
+                game = current,
+                pgnSharer = pgnSharer,
+                onBack = { selectedGame = null },
+            )
+        }
+    }
+}
+
+@Composable
+private fun GameHistoryList(
+    games: List<SavedGame>,
+    pgnSharer: PgnSharer?,
+    onOpen: (SavedGame) -> Unit,
+    onDelete: (SavedGame) -> Unit,
+) {
+    if (games.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize().padding(24.dp), contentAlignment = Alignment.Center) {
+            Text(
+                "No saved games yet. Finish a game and tap “Save game” to add one.",
+                modifier = Modifier.testTag("history_empty"),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        return
+    }
+
+    // Each row: date, result, players, move count. The whole card is selectable.
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        items(games, key = { it.id }) { game ->
+            GameHistoryRow(
+                game = game,
+                canShare = pgnSharer != null,
+                onOpen = { onOpen(game) },
+                onShare = { pgnSharer?.share(game.pgn, "game-${game.result}.pgn") },
+                onDelete = { onDelete(game) },
+            )
+            HorizontalDivider()
+        }
+    }
+}
+
+@Composable
+private fun GameHistoryRow(
+    game: SavedGame,
+    canShare: Boolean,
+    onOpen: () -> Unit,
+    onShare: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .testTag("history_row_${game.id}")
+            .selectable(selected = false, onClick = onOpen),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                "${game.white} vs ${game.black}",
+                style = MaterialTheme.typography.titleSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                "Result: ${game.result}  •  ${game.moveCount} moves",
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Row(
+                modifier = Modifier.padding(top = 6.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(onClick = onOpen, modifier = Modifier.testTag("history_view_${game.id}")) {
+                    Text("View")
+                }
+                if (canShare) {
+                    Button(
+                        onClick = onShare,
+                        modifier = Modifier.testTag("history_share_${game.id}"),
+                    ) { Text("Share") }
+                }
+                Button(
+                    onClick = onDelete,
+                    modifier = Modifier.testTag("history_delete_${game.id}"),
+                ) { Text("Delete") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GameHistoryDetail(
+    game: SavedGame,
+    pgnSharer: PgnSharer?,
+    onBack: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(onClick = onBack) { Text("Back") }
+            Text(
+                "${game.white} vs ${game.black}  •  ${game.result}",
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+        Spacer(modifier = Modifier.padding(6.dp))
+        // The PGN text. heightIn(min) keeps it scrollable/visible on small screens; the surfaceVariant
+        // card makes the selectable text block visually distinct.
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        ) {
+            Text(
+                text = game.pgn,
+                modifier = Modifier
+                    .padding(12.dp)
+                    .heightIn(min = 200.dp)
+                    .testTag("history_detail_pgn"),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        Spacer(modifier = Modifier.padding(6.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            if (pgnSharer != null) {
+                Button(
+                    onClick = { pgnSharer.share(game.pgn, "game-${game.result}.pgn") },
+                    modifier = Modifier.testTag("history_detail_share"),
+                ) { Text("Share PGN") }
+            }
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameHistoryScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameHistoryScreen.kt
@@ -51,8 +51,8 @@ fun GameHistoryScreen(
     val games by gameHistory.games.collectAsState()
     var selectedGame by remember { mutableStateOf<SavedGame?>(null) }
 
-    SubScreenScaffold(title = "Game History", onBack = onBack) {
-        val current = selectedGame
+    val current = selectedGame
+    SubScreenScaffold(title = "Game History", onBack = onBack, scrollable = current != null) {
         if (current == null) {
             GameHistoryList(
                 games = games,

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameScreen.kt
@@ -4,6 +4,9 @@ import com.example.myapplication.board3d.Board3D
 import com.example.myapplication.board3d.Board3DSupport
 import com.example.myapplication.board3d.BoardSquare
 import com.example.myapplication.board3d.Board3DSessionState
+import com.example.myapplication.persistence.GameActions
+import com.example.myapplication.persistence.GameHistoryRepository
+import com.example.myapplication.share.PgnSharer
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -133,6 +136,8 @@ fun GameScreen(
     windowSize: WindowWidthSizeClass,
     viewModel: GameViewModel,
     board3D: Board3DSupport? = null,
+    gameHistory: GameHistoryRepository? = null,
+    pgnSharer: PgnSharer? = null,
     switchTopPadding: Dp = 8.dp,
     onOpenHistory: () -> Unit = {},
     onOpenSettings: () -> Unit = {},
@@ -149,6 +154,11 @@ fun GameScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (gameState.winState != WinState.NONE && !viewState.hideWindow) {
+            // `gameSaved` guards against double-saves of the same finished game (tapping "Save game"
+            // twice). Reset whenever a new game-over is shown (winState transitions back to NONE
+            // between games, or hideWindow flips). Keyed on the result token so a genuinely new
+            // finished game can be saved even if the previous popup wasn't dismissed.
+            var gameSaved by remember(gameState.winState, gameState.fullmoveNumber) { mutableStateOf(false) }
             val resetGame = { reset: Boolean ->
                 if (reset) {
                     viewModel.resetGame()
@@ -188,6 +198,43 @@ fun GameScreen(
                         onClick = { resetGame(false) }
                     ) {
                         Text(stringResource(Res.string.cancel_button))
+                    }
+                }
+
+                // Save / Share PGN (issue #39 Phase 3). Save writes to GameHistory; Share routes
+                // through the platform PgnSharer. Both hidden when there's no gameHistory (Save) /
+                // no pgnSharer (Share) — mirroring the board3D-null gating.
+                if (gameHistory != null || pgnSharer != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        if (gameHistory != null) {
+                            Button(
+                                modifier = Modifier
+                                    .padding(5.dp)
+                                    .testTag("save_game_button"),
+                                enabled = !gameSaved,
+                                onClick = {
+                                    val saved = GameActions.toSavedGame(gameState, viewModel.engineAttached)
+                                    gameHistory.add(saved)
+                                    gameSaved = true
+                                }
+                            ) {
+                                Text(if (gameSaved) "Saved" else "Save game")
+                            }
+                        }
+                        if (pgnSharer != null) {
+                            Button(
+                                modifier = Modifier
+                                    .padding(5.dp)
+                                    .testTag("share_pgn_button"),
+                                onClick = {
+                                    val pgn = GameActions.toPgn(gameState, viewModel.engineAttached)
+                                    pgnSharer.share(pgn, "game-${PgnSerializer.resultToken(gameState.winState)}.pgn")
+                                }
+                            ) {
+                                Text("Share PGN")
+                            }
+                        }
                     }
                 }
             }
@@ -739,20 +786,18 @@ fun AnimatedChessPiece(
 
 @Composable
 fun PopupWindow(onDismiss: (Boolean) -> Unit, content: @Composable () -> Unit) {
-    val height = 200.dp
     val cornerRoundness = 25.dp
     val contentPadding = 15.dp
 
     Dialog(onDismissRequest = { onDismiss(false) }) {
         Card(
-            modifier = Modifier.fillMaxWidth().height(height),
+            modifier = Modifier.fillMaxWidth(),
             shape = RoundedCornerShape(cornerRoundness),
         ) {
             Column(
                 modifier = Modifier
-                    .fillMaxSize()
                     .padding(contentPadding)
-                    .wrapContentHeight(),
+                    .wrapContentHeight(Alignment.CenterVertically),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 content()

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
@@ -36,6 +36,10 @@ class GameViewModel(
     private var gameMoves: Job? = null
     private var chessEngine: ChessEngine? = null
 
+    /** `true` when a real engine (Stockfish) drives Black; `false` = built-in CPU fallback.
+     *  Used for PGN player naming (issue #39 Phase 3: Black = "Stockfish" vs "CPU"). */
+    val engineAttached: Boolean get() = chessEngine != null
+
     companion object {
         private val logger = Logger.withTag("GameViewModel")
     }

--- a/app/src/commonMain/kotlin/com/example/myapplication/persistence/Clock.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/persistence/Clock.kt
@@ -1,0 +1,15 @@
+package com.example.myapplication.persistence
+
+/**
+ * Platform clock for the persistence/history layer. `commonMain` has no `kotlinx-datetime` dep (the
+ * plan deliberately avoids adding one), so epoch millis and the PGN `YYYY.MM.DD` date string are
+ * sourced from each platform's native clock via this tiny `expect/actual`.
+ *
+ *  - [nowEpochMillis]: monotonic-ish wall time; used for `SavedGame.savedAtEpochMillis` and the
+ *    autosave timestamp. Sufficient for ordering/newest-first; not a monotonic clock.
+ *  - [todayPgnDate]: today's date in `YYYY.MM.DD` (PGN spec §10), UTC. `?`/partial dates are not used.
+ */
+expect fun nowEpochMillis(): Long
+
+/** Today's date in PGN `YYYY.MM.DD` form (UTC). */
+expect fun todayPgnDate(): String

--- a/app/src/commonMain/kotlin/com/example/myapplication/persistence/GameActions.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/persistence/GameActions.kt
@@ -1,0 +1,45 @@
+package com.example.myapplication.persistence
+
+import com.example.myapplication.GameUiState
+import com.example.myapplication.PgnSerializer
+import com.example.myapplication.PgnTags
+
+/**
+ * Builds the PGN artifacts saved/shared at game end (Phase 3). Pure logic — no platform or UI deps —
+ * so it's unit-testable in `commonTest`.
+ *
+ * The player naming follows the plan: White is always the human "Player"; Black is "Stockfish" when
+ * a real engine is attached, else "CPU".
+ */
+object GameActions {
+
+    /** Builds the [PgnTags] for the finished [state]. */
+    fun pgnTags(state: GameUiState, engineAttached: Boolean, date: String = todayPgnDate()): PgnTags = PgnTags(
+        date = date,
+        white = "Player",
+        black = if (engineAttached) "Stockfish" else "CPU",
+        result = PgnSerializer.resultToken(state.winState),
+    )
+
+    /** Builds the full PGN string (tags + movetext + result) for the finished [state]. */
+    fun toPgn(state: GameUiState, engineAttached: Boolean, date: String = todayPgnDate()): String =
+        PgnSerializer.toPgn(pgnTags(state, engineAttached, date), state.moveHistory)
+
+    /**
+     * Builds a [SavedGame] ready for [GameHistoryRepository.add]. The [id] is derived from
+     * [savedAtEpochMillis] (falling back to a UUID-ish suffix on collision within the same ms is
+     * unnecessary at this call rate — the repo dedupes by exact id on delete only).
+     */
+    fun toSavedGame(state: GameUiState, engineAttached: Boolean, savedAtEpochMillis: Long = nowEpochMillis()): SavedGame {
+        val pgn = toPgn(state, engineAttached, date = todayPgnDate())
+        return SavedGame(
+            id = savedAtEpochMillis.toString(),
+            savedAtEpochMillis = savedAtEpochMillis,
+            result = PgnSerializer.resultToken(state.winState),
+            white = "Player",
+            black = if (engineAttached) "Stockfish" else "CPU",
+            moveCount = state.moveHistory.size,
+            pgn = pgn,
+        )
+    }
+}

--- a/app/src/commonMain/kotlin/com/example/myapplication/persistence/GameHistory.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/persistence/GameHistory.kt
@@ -1,0 +1,72 @@
+package com.example.myapplication.persistence
+
+import com.russhwolf.settings.Settings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * A finished game saved to the Game History (Phase 3). Built from a [com.example.myapplication.PgnTags]
+ * + serialized PGN movetext at game end and listed on the History screen.
+ *
+ * - [id] is derived from the save timestamp (+ a counter on collision) — `commonMain` has no UUID,
+ *   and a monotonic-ish timestamp id is all that's needed to key a LazyColumn.
+ * - [pgn] is the full PGN string (tags + movetext + result); that's what "Share" ships and what the
+ *   detail view shows verbatim.
+ */
+@Serializable
+data class SavedGame(
+    val id: String,
+    val savedAtEpochMillis: Long,
+    val result: String,        // "1-0" etc.
+    val white: String,
+    val black: String,
+    val moveCount: Int,
+    val pgn: String,
+)
+
+/**
+ * Persists the list of [SavedGame]s to the russhwolf [Settings] backend as one JSON blob, exposing
+ * a [StateFlow] for the History screen. Newest first; capped at [MAX_GAMES] (oldest dropped).
+ *
+ * Like [CurrentGameStore], the blob lives under a **versioned** key (`game_history.v1`) and [load]
+ * is tolerant — corrupt JSON yields an empty list rather than crashing. `ignoreUnknownKeys` keeps
+ * older blobs readable after a [SavedGame] field is added.
+ */
+class GameHistoryRepository(
+    private val settings: Settings,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+    private val _games = MutableStateFlow(load())
+    val games: StateFlow<List<SavedGame>> get() = _games
+
+    /** Prepends [game], persists, and updates the flow. Drops the oldest entry past the cap. */
+    fun add(game: SavedGame) {
+        val updated = (listOf(game) + _games.value).take(MAX_GAMES)
+        persist(updated)
+    }
+
+    /** Removes the game with [id] (if present), persists, and updates the flow. */
+    fun delete(id: String) {
+        val updated = _games.value.filterNot { it.id == id }
+        persist(updated)
+    }
+
+    private fun persist(games: List<SavedGame>) {
+        settings.putString(KEY, json.encodeToString(ListSerializer(SavedGame.serializer()), games))
+        _games.value = games
+    }
+
+    private fun load(): List<SavedGame> =
+        settings.getStringOrNull(KEY)?.let {
+            runCatching { json.decodeFromString(ListSerializer(SavedGame.serializer()), it) }
+                .getOrNull()
+        } ?: emptyList()
+
+    companion object {
+        const val KEY = "game_history.v1"
+        const val MAX_GAMES = 200
+    }
+}

--- a/app/src/commonMain/kotlin/com/example/myapplication/share/PgnSharer.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/share/PgnSharer.kt
@@ -1,0 +1,16 @@
+package com.example.myapplication.share
+
+/**
+ * Platform share/export for a PGN string (Phase 3). Mirrors the [com.example.myapplication.board3d.Board3DSupport]
+ * / [com.example.myapplication.ChessEngine] injection pattern: each target's entry point constructs
+ * a platform-specific implementation and passes it into `AppRoot`; targets that defer it pass `null`,
+ * and the Share button is hidden when `pgnSharer == null` (just like the 3D toggle).
+ *
+ * The contract is fire-and-forget: implementors open the platform share sheet / file dialog /
+ * download and return immediately. [suggestedFileName] is a hint (no extension enforced).
+ *
+ * Declared `fun interface` so tests can use SAM conversion (`PgnSharer { _, _ -> }`).
+ */
+fun interface PgnSharer {
+    fun share(pgn: String, suggestedFileName: String)
+}

--- a/app/src/commonTest/kotlin/com/example/myapplication/persistence/GameActionsTest.kt
+++ b/app/src/commonTest/kotlin/com/example/myapplication/persistence/GameActionsTest.kt
@@ -1,0 +1,72 @@
+package com.example.myapplication.persistence
+
+import com.example.myapplication.GameUiState
+import com.example.myapplication.WinState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GameActionsTest {
+
+    @Test
+    fun `pgnTags names Stockfish when engine attached and CPU otherwise`() {
+        val state = GameUiState(winState = WinState.WHITE)
+
+        val withEngine = GameActions.pgnTags(state, engineAttached = true, date = "2026.07.02")
+        assertEquals("Stockfish", withEngine.black)
+
+        val withCpu = GameActions.pgnTags(state, engineAttached = false, date = "2026.07.02")
+        assertEquals("CPU", withCpu.black)
+    }
+
+    @Test
+    fun `pgnTags date and result come from state`() {
+        val state = GameUiState(winState = WinState.DRAW)
+        val tags = GameActions.pgnTags(state, engineAttached = false, date = "2026.07.02")
+        assertEquals("2026.07.02", tags.date)
+        assertEquals("1/2-1/2", tags.result)
+        assertEquals("Player", tags.white)
+    }
+
+    @Test
+    fun `toPgn produces a complete PGN with tags and movetext`() = kotlinx.coroutines.test.runTest {
+        // A one-move game: 1.e4 then White "wins" (contrived for the test). The PGN must contain the
+        // Seven Tag Roster and the e4 SAN.
+        val vm = com.example.myapplication.GameViewModel()
+        vm.moveCPU(com.example.myapplication.Set.WHITE) { _, _, _, _ ->
+            com.example.myapplication.SelectedMove(
+                kotlin.Pair(4, 4),
+                vm.gameState.value.positionsWhite.indexOf(kotlin.Pair(6, 4))
+            )
+        }
+        val finished = vm.gameState.value.copy(winState = WinState.WHITE)
+        val pgn = GameActions.toPgn(finished, engineAttached = true, date = "2026.07.02")
+
+        assertTrue("[White \"Player\"]" in pgn)
+        assertTrue("[Black \"Stockfish\"]" in pgn)
+        assertTrue("[Date \"2026.07.02\"]" in pgn)
+        assertTrue("[Result \"1-0\"]" in pgn)
+        assertTrue("e4" in pgn)
+    }
+
+    @Test
+    fun `toSavedGame captures id result moveCount and pgn`() = kotlinx.coroutines.test.runTest {
+        val vm = com.example.myapplication.GameViewModel()
+        vm.moveCPU(com.example.myapplication.Set.WHITE) { _, _, _, _ ->
+            com.example.myapplication.SelectedMove(
+                kotlin.Pair(4, 4),
+                vm.gameState.value.positionsWhite.indexOf(kotlin.Pair(6, 4))
+            )
+        }
+        val finished = vm.gameState.value.copy(winState = WinState.WHITE)
+        val saved = GameActions.toSavedGame(finished, engineAttached = true, savedAtEpochMillis = 1_700_000_000_000L)
+
+        assertEquals("1700000000000", saved.id)
+        assertEquals(1_700_000_000_000L, saved.savedAtEpochMillis)
+        assertEquals("1-0", saved.result)
+        assertEquals("Player", saved.white)
+        assertEquals("Stockfish", saved.black)
+        assertEquals(1, saved.moveCount)
+        assertTrue("e4" in saved.pgn)
+    }
+}

--- a/app/src/commonTest/kotlin/com/example/myapplication/persistence/GameHistoryRepositoryTest.kt
+++ b/app/src/commonTest/kotlin/com/example/myapplication/persistence/GameHistoryRepositoryTest.kt
@@ -1,0 +1,94 @@
+package com.example.myapplication.persistence
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GameHistoryRepositoryTest {
+
+    private fun savedGame(id: String, millis: Long = id.toLong()) = SavedGame(
+        id = id,
+        savedAtEpochMillis = millis,
+        result = "1-0",
+        white = "Player",
+        black = "Stockfish",
+        moveCount = 10,
+        pgn = "[Event \"Casual Game\"]\n...",
+    )
+
+    @Test
+    fun `starts empty when nothing is saved`() {
+        val repo = GameHistoryRepository(MapSettings())
+        assertTrue(repo.games.value.isEmpty())
+    }
+
+    @Test
+    fun `add prepends and the flow reflects newest first`() {
+        val repo = GameHistoryRepository(MapSettings())
+        repo.add(savedGame("1", 1_000))
+        repo.add(savedGame("2", 2_000))
+        repo.add(savedGame("3", 3_000))
+
+        assertEquals(listOf("3", "2", "1"), repo.games.value.map { it.id })
+    }
+
+    @Test
+    fun `add persists so a fresh repo over the same backing reads it`() {
+        val backing = MapSettings()
+        GameHistoryRepository(backing).add(savedGame("7", 7_000))
+
+        val reloaded = GameHistoryRepository(backing)
+        assertEquals(listOf("7"), reloaded.games.value.map { it.id })
+    }
+
+    @Test
+    fun `delete removes the matching id and updates the flow`() {
+        val repo = GameHistoryRepository(MapSettings())
+        repo.add(savedGame("1"))
+        repo.add(savedGame("2"))
+        repo.add(savedGame("3"))
+
+        repo.delete("2")
+
+        assertEquals(listOf("3", "1"), repo.games.value.map { it.id })
+        assertFalse(repo.games.value.any { it.id == "2" })
+    }
+
+    @Test
+    fun `delete of a missing id is a no-op`() {
+        val repo = GameHistoryRepository(MapSettings())
+        repo.add(savedGame("1"))
+        repo.delete("does-not-exist")
+        assertEquals(listOf("1"), repo.games.value.map { it.id })
+    }
+
+    @Test
+    fun `cap evicts the oldest entries past MAX_GAMES`() {
+        val repo = GameHistoryRepository(MapSettings())
+        // Fill to the cap.
+        repeat(GameHistoryRepository.MAX_GAMES) { repo.add(savedGame(it.toString(), it.toLong())) }
+        assertEquals(GameHistoryRepository.MAX_GAMES, repo.games.value.size)
+        // The newest is the last added (id = MAX_GAMES - 1).
+        assertEquals((GameHistoryRepository.MAX_GAMES - 1).toString(), repo.games.value.first().id)
+
+        // One more should evict the oldest (id = "0").
+        repo.add(savedGame("overflow", 1_000_000L))
+        assertEquals(GameHistoryRepository.MAX_GAMES, repo.games.value.size)
+        assertFalse(repo.games.value.any { it.id == "0" })
+        assertEquals("overflow", repo.games.value.first().id)
+    }
+
+    @Test
+    fun `corrupt blob yields an empty list instead of throwing`() {
+        val backing = MapSettings()
+        backing.putString(GameHistoryRepository.KEY, "{ not valid json")
+        val repo = GameHistoryRepository(backing)
+        assertTrue(repo.games.value.isEmpty())
+    }
+
+    @Test
+    fun `version key is v1`() {
+        assertEquals("game_history.v1", GameHistoryRepository.KEY)
+    }
+}

--- a/app/src/desktopMain/kotlin/com/example/myapplication/Main.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/Main.kt
@@ -9,12 +9,14 @@ import androidx.compose.ui.unit.dp
 import com.example.myapplication.persistence.AppSettings
 import com.example.myapplication.persistence.CurrentGameStore
 import com.example.myapplication.persistence.CurrentGameStoreSupport
+import com.example.myapplication.persistence.GameHistoryRepository
 import com.example.myapplication.persistence.createSettings
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import com.example.myapplication.board3d.desktopBoard3DSupport
+import com.example.myapplication.share.desktopPgnSharer
 
 fun main() = application {
     // One Settings backing store shared by AppSettings and the autosave store (Phase 2). `remember`
@@ -30,6 +32,8 @@ fun main() = application {
     val viewModel = remember { GameViewModel(restoredState.state, currentGameStore) }
     val board3D = remember { desktopBoard3DSupport() }
     val appSettings = remember { AppSettings(settings) }
+    val gameHistory = remember { GameHistoryRepository(settings) }
+    val pgnSharer = remember { desktopPgnSharer() }
 
     DisposableEffect(Unit) {
         val engine = DesktopStockfishEngine()
@@ -54,7 +58,9 @@ fun main() = application {
         AppRoot(
             viewModel = viewModel,
             settings = appSettings,
-            board3D = board3D
+            board3D = board3D,
+            gameHistory = gameHistory,
+            pgnSharer = pgnSharer,
         )
     }
 }

--- a/app/src/desktopMain/kotlin/com/example/myapplication/share/PgnSharer.desktop.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/share/PgnSharer.desktop.kt
@@ -1,0 +1,31 @@
+package com.example.myapplication.share
+
+import java.awt.FileDialog
+import java.awt.Frame
+import java.io.File
+import java.io.FileWriter
+
+/**
+ * Desktop [PgnSharer]. Opens a save [FileDialog] (native file chooser) defaulting to
+ * [suggestedFileName], and writes the PGN to the chosen path. Falls back to no-op if the user
+ * cancels. (Clipboard copy is a future enhancement; a file is the more useful desktop export and
+ * matches "Save game" intent.)
+ *
+ * Runs on the EDT via the AWT frame; `FileDialog.LOAD`/`SAVE` are modal so this blocks until the
+ * user picks a file or cancels.
+ */
+class DesktopPgnSharer : PgnSharer {
+    override fun share(pgn: String, suggestedFileName: String) {
+        val dialog = FileDialog(Frame(), "Save PGN", FileDialog.SAVE).apply {
+            file = suggestedFileName
+            isVisible = true
+        }
+        val selected = dialog.file ?: return  // user cancelled
+        val dir = dialog.directory ?: return
+        val target = File(dir, selected)
+        FileWriter(target).use { it.write(pgn) }
+    }
+}
+
+/** Factory mirroring `desktopBoard3DSupport()` — constructed at the desktop entry point. */
+fun desktopPgnSharer(): PgnSharer = DesktopPgnSharer()

--- a/app/src/iosMain/kotlin/com/example/myapplication/MainViewController.kt
+++ b/app/src/iosMain/kotlin/com/example/myapplication/MainViewController.kt
@@ -9,7 +9,9 @@ import androidx.compose.ui.unit.dp
 import com.example.myapplication.persistence.AppSettings
 import com.example.myapplication.persistence.CurrentGameStore
 import com.example.myapplication.persistence.CurrentGameStoreSupport
+import com.example.myapplication.persistence.GameHistoryRepository
 import com.example.myapplication.persistence.createSettings
+import com.example.myapplication.share.iosPgnSharer
 
 /**
  * iOS entry point. The engine is created and started on the Swift side
@@ -35,6 +37,8 @@ fun MainViewController(
     }
     val viewModel = remember { GameViewModel(restoredState.state, currentGameStore) }
     val appSettings = remember { AppSettings(settings) }
+    val gameHistory = remember { GameHistoryRepository(settings) }
+    val pgnSharer = remember { iosPgnSharer() }
     DisposableEffect(Unit) {
         viewModel.attachEngine(engine)
         if (platform.posix.getenv("CHESS_START_3D") != null) viewModel.setShow3D(true)
@@ -44,6 +48,8 @@ fun MainViewController(
         viewModel = viewModel,
         settings = appSettings,
         board3D = remember { com.example.myapplication.board3d.iosBoard3DSupport(filamentFactory) },
+        gameHistory = gameHistory,
+        pgnSharer = pgnSharer,
         switchTopPadding = (-16).dp
     )
 }

--- a/app/src/iosMain/kotlin/com/example/myapplication/persistence/Clock.ios.kt
+++ b/app/src/iosMain/kotlin/com/example/myapplication/persistence/Clock.ios.kt
@@ -1,0 +1,41 @@
+package com.example.myapplication.persistence
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
+
+/** iOS actual for [nowEpochMillis]/[todayPgnDate]. */
+@OptIn(ExperimentalForeignApi::class)
+actual fun nowEpochMillis(): Long =
+    ((NSDate().timeIntervalSince1970) * 1000.0).toLong()
+
+/**
+ * Today's date in PGN `YYYY.MM.DD` form (UTC). Computed directly from the epoch to avoid the
+ * platform NSTimeZone factory (whose Kotlin/Native mapping is finicky). Standard civil-calendar
+ * conversion from days-since-epoch; UTC by construction.
+ */
+actual fun todayPgnDate(): String {
+    val epochSeconds = (nowEpochMillis() / 1000L)
+    val dayNumber = epochSeconds / SECONDS_PER_DAY   // whole days since 1970-01-01 (UTC)
+    val (y, m, d) = civilFromDays(dayNumber)
+    return "${y.toString().padStart(4, '0')}." +
+        "${m.toString().padStart(2, '0')}." +
+        d.toString().padStart(2, '0')
+}
+
+// --- Howard Hinnant's days_from_civil / civil_from_days (proleptic Gregorian, UTC) ---
+
+private const val SECONDS_PER_DAY = 86_400L
+
+private fun civilFromDays(z: Long): Triple<Int, Int, Int> {
+    val z = z + 719_468L
+    val era = if (z >= 0) z else z - 146_096L / 146_097L
+    val doe = (z - era * 146_097L).toInt()                       // [0, 146096]
+    val yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365    // [0, 399]
+    val y = yoe + (era * 400).toInt()
+    val doy = doe - (365 * yoe + yoe / 4 - yoe / 100)             // [0, 365]
+    val mp = (5 * doy + 2) / 153                                  // [0, 11]
+    val d = doy - (153 * mp + 2) / 5 + 1                          // [1, 31]
+    val m = if (mp < 10) mp + 3 else mp - 9                       // [1, 12]
+    return Triple(if (m <= 2) y + 1 else y, m, d)
+}

--- a/app/src/iosMain/kotlin/com/example/myapplication/share/PgnSharer.ios.kt
+++ b/app/src/iosMain/kotlin/com/example/myapplication/share/PgnSharer.ios.kt
@@ -1,0 +1,49 @@
+package com.example.myapplication.share
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSString
+import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIApplication
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
+
+/**
+ * iOS [PgnSharer]. Presents a [UIActivityViewController] with the PGN as text from the active
+ * scene's key window's root view controller. (Sharing an `NSString` covers Mail/Notes/Messages/AirDrop
+ * and "Copy" — sufficient for PGN export without a tmp-file URI.)
+ */
+@OptIn(ExperimentalForeignApi::class)
+class IosPgnSharer : PgnSharer {
+    override fun share(pgn: String, suggestedFileName: String) {
+        val presenter = topViewController() ?: return
+        val activityItems = listOf<Any>(pgn as NSString)
+        val activityVC = UIActivityViewController(activityItems = activityItems, applicationActivities = null)
+        presenter.presentViewController(activityVC, animated = true, completion = null)
+    }
+
+    private fun topViewController(): UIViewController? {
+        val window = keyWindow() ?: return null
+        var top = window.rootViewController ?: return null
+        while (top.presentedViewController != null) top = top.presentedViewController!!
+        return top
+    }
+
+    /** Finds the first window across the app's connected scenes (single-window app). */
+    @Suppress("UNCHECKED_CAST")
+    private fun keyWindow(): UIWindow? {
+        val scenes = UIApplication.sharedApplication.connectedScenes
+        for (scene in scenes) {
+            val windowScene = scene as? UIWindowScene ?: continue
+            // `UIWindowScene.windows` is typed `List<*>` in this K/N binding; cast the elements.
+            // Single-window app: the first window hosts Compose.
+            val windows = windowScene.windows as List<UIWindow>
+            val first = windows.firstOrNull()
+            if (first != null) return first
+        }
+        return null
+    }
+}
+
+/** Factory mirroring `iosBoard3DSupport(...)` — constructed at the iOS entry point. */
+fun iosPgnSharer(): PgnSharer = IosPgnSharer()

--- a/app/src/jvmCommonMain/kotlin/com/example/myapplication/persistence/Clock.jvm.kt
+++ b/app/src/jvmCommonMain/kotlin/com/example/myapplication/persistence/Clock.jvm.kt
@@ -1,0 +1,16 @@
+package com.example.myapplication.persistence
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/** Shared JVM actual (covers Android + Desktop) for [nowEpochMillis]/[todayPgnDate]. */
+actual fun nowEpochMillis(): Long = System.currentTimeMillis()
+
+actual fun todayPgnDate(): String {
+    // PGN spec §10: "YYYY.MM.DD". UTC so a game finished near midnight doesn't flip the date by TZ.
+    val fmt = SimpleDateFormat("yyyy.MM.dd", Locale.US)
+    fmt.timeZone = TimeZone.getTimeZone("UTC")
+    return fmt.format(Date())
+}

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/Main.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/Main.kt
@@ -9,7 +9,9 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import com.example.myapplication.persistence.AppSettings
 import com.example.myapplication.persistence.CurrentGameStore
 import com.example.myapplication.persistence.CurrentGameStoreSupport
+import com.example.myapplication.persistence.GameHistoryRepository
 import com.example.myapplication.persistence.createSettings
+import com.example.myapplication.share.wasmPgnSharer
 import co.touchlab.kermit.Logger
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -26,6 +28,8 @@ fun main() {
         }
         val viewModel = remember { GameViewModel(restoredState.state, currentGameStore) }
         val appSettings = remember { AppSettings(settings) }
+        val gameHistory = remember { GameHistoryRepository(settings) }
+        val pgnSharer = remember { wasmPgnSharer() }
         LaunchedEffect(Unit) {
             val engine = WasmStockfishEngine()
             if (engine.start()) {
@@ -42,7 +46,9 @@ fun main() {
         AppRoot(
             viewModel = viewModel,
             settings = appSettings,
-            board3D = com.example.myapplication.board3d.wasmBoard3DSupport(viewModel)
+            board3D = com.example.myapplication.board3d.wasmBoard3DSupport(viewModel),
+            gameHistory = gameHistory,
+            pgnSharer = pgnSharer,
         )
     }
 }

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/persistence/Clock.wasmJs.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/persistence/Clock.wasmJs.kt
@@ -1,0 +1,13 @@
+package com.example.myapplication.persistence
+
+/** Wasm/JS actual for [nowEpochMillis]/[todayPgnDate] backed by the browser `Date`. */
+
+@JsFun("() => Date.now()")
+private external fun jsNow(): Double
+
+actual fun nowEpochMillis(): Long = jsNow().toLong()
+
+@JsFun("() => { const d = new Date(); const y = d.getUTCFullYear(); const m = String(d.getUTCMonth() + 1).padStart(2, '0'); const day = String(d.getUTCDate()).padStart(2, '0'); return y + '.' + m + '.' + day; }")
+private external fun jsTodayPgnDate(): String
+
+actual fun todayPgnDate(): String = jsTodayPgnDate()

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/share/PgnSharer.wasmJs.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/share/PgnSharer.wasmJs.kt
@@ -1,0 +1,19 @@
+package com.example.myapplication.share
+
+/**
+ * Wasm/JS [PgnSharer]. Creates a `Blob` from the PGN, an object URL, and a synthetic
+ * `<a download="suggestedFileName">` click to trigger a browser download. Fire-and-forget — no
+ * `Promise.await` (avoids the known wasm `Promise.await` GC pitfall noted in the plan). The object
+ * URL is revoked after the click.
+ */
+class WasmPgnSharer : PgnSharer {
+    override fun share(pgn: String, suggestedFileName: String) {
+        downloadText(pgn, suggestedFileName)
+    }
+}
+
+@JsFun("(text, filename) => { const blob = new Blob([text], {type: 'application/x-chess-pgn'}); const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = filename; document.body.appendChild(a); a.click(); document.body.removeChild(a); URL.revokeObjectURL(url); }")
+private external fun downloadText(text: String, filename: String)
+
+/** Factory mirroring `wasmBoard3DSupport(...)` — constructed at the wasm entry point. */
+fun wasmPgnSharer(): PgnSharer = WasmPgnSharer()


### PR DESCRIPTION
Step 3 of the `docs/plans/issue-39-game-lifecycle-persistence.md` plan — Phase 3 (Game History screen + Save game + Share PGN). Builds on the merged Phase 0/1/2 work (#56, #64).

## What this does

On game end, the user can now **save** the finished game and **share** its PGN; a **History** screen lists saved games. Works across all four targets (Android, desktop, web/Wasm, iOS).

### Persistence (`commonMain`)
- **`SavedGame`** + **`GameHistoryRepository`** — persists the list of finished games as one JSON blob under a versioned key (`game_history.v1`); exposes a `StateFlow<List<SavedGame>>` (newest first); caps at 200 games (oldest dropped); tolerant of corrupt blobs (returns empty list instead of crashing).
- **`Clock.kt` expect/actual** — `nowEpochMillis()` / `todayPgnDate()` so `commonMain` can stamp saves without adding `kotlinx-datetime`. JVM actual lives in `jvmCommonMain` (covers Android + Desktop); wasm uses `@JsFun(Date)`; iOS computes the UTC date from the epoch directly (avoids the finicky `NSTimeZone` Kotlin/Native mapping).
- **`GameActions`** — pure helper that builds `PgnTags`/`SavedGame` from a `GameUiState` (Black = "Stockfish" if an engine is attached, else "CPU"). Unit-tested.

### Share (`commonMain` + platform actuals)
- **`PgnSharer`** `fun interface`, injected exactly like `Board3DSupport` (null hides the Share button). Platform actuals:
  - **Android** — `ACTION_SEND` + `EXTRA_TEXT` (no FileProvider/manifest changes needed; the plan's explicit fallback).
  - **Desktop** — native `FileDialog` (save) writing the `.pgn`.
  - **iOS** — `UIActivityViewController` from the key window's root VC.
  - **Wasm** — `Blob` + object URL + synthetic `<a download>` click (fire-and-forget, no `Promise.await`).

### UI
- **`GameScreen`** game-over popup gains **Save game** (double-save guarded via a `gameSaved` flag) and **Share PGN** buttons, each hidden when `gameHistory`/`pgnSharer` are null. `PopupWindow` now wraps content height instead of a fixed 200dp to accommodate the extra row.
- **`GameHistoryScreen`** — `LazyColumn` list (result/players/move count) + an inline detail view with selectable PGN and **Share**/**Delete** actions; empty state. Replaces the `AppRoot` placeholder. `testTag`s throughout (`history_row_<id>`, `history_empty`, `history_share_<id>`, `history_delete_<id>`, `save_game_button`, `share_pgn_button`, ...).
- **`GameViewModel`** exposes `engineAttached` for PGN player naming.

### Wiring
All four entry points construct `GameHistoryRepository` + `PgnSharer` and thread them through `AppRoot`. Android's `AndroidGameViewModel` holder owns the repo (survives config changes); the sharer is built in `onCreate` (needs the host `Activity`).

## Tests
- `GameHistoryRepositoryTest` (commonTest) — add/delete/load round-trips; newest-first ordering; cap eviction at `MAX_GAMES`; corrupt blob tolerated; version key.
- `GameActionsTest` (commonTest) — PGN tags/players/result; full PGN contains the Seven Tag Roster + movetext; `SavedGame` fields (id/result/moveCount/pgn).
- `SaveGameHistoryTest` (androidDeviceTest) — end-to-end Save → History → Delete on the real `SharedPreferences` backend with a fake `PgnSharer`.

## Verification
- `./gradlew :app:check` ✅ — `testAndroid`, `testAndroidHostTest`, `wasmJsBrowserTest`, `wasmJsTest`, `allTests`, + iOS test compile.
- Full CI gate builds ✅ — `:androidApp:assembleDebug`, `:app:desktopJar`, `:app:packageDistributionForCurrentOS`, `:app:wasmJsBrowserDistribution`.
- `:app:assembleAndroidDeviceTest` ✅ (new instrumented test compiles).

Instrumented Android device tests (`connectedAndroidDeviceTest`) and iOS simulator tests need a device/simulator — left to CI.

Closes the Phase 3 step of #39.