### PR TITLE
feat(ui): move 3D toggle to Settings + persist (default on)

### DIFF
--- a/app/src/androidMain/kotlin/com/example/myapplication/MainActivity.kt
+++ b/app/src/androidMain/kotlin/com/example/myapplication/MainActivity.kt
@@ -80,7 +80,9 @@ class AndroidGameViewModel : ViewModel() {
     private val settings = createSettings("chess")
     private val currentGameStore = CurrentGameStore(settings)
     private val restoredState = CurrentGameStoreSupport.loadInitialState(currentGameStore)
-    val gameViewModel = GameViewModel(restoredState.state, currentGameStore)
+    // Seed the VM's runtime show3D from the persisted setting (3D on by default on first install).
+    private val initialShow3D = AppSettings(settings).board3DEnabled.value
+    val gameViewModel = GameViewModel(restoredState.state, currentGameStore, initialShow3D = initialShow3D)
 
     // Phase 3: saved-games history lives on the same Settings backing store, owned by the holder so
     // it survives config changes (and is observed by the History screen across recompositions).

--- a/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
@@ -78,7 +78,10 @@ fun AppRoot(
                         Text("Game history is unavailable.")
                     }
                 }
-                Screen.SETTINGS -> SettingsScreen(onBack = { screen = Screen.GAME })
+                Screen.SETTINGS -> SettingsScreen(
+                    onBack = { screen = Screen.GAME },
+                    board3D = board3D,
+                )
             }
         }
     }

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameScreen.kt
@@ -6,6 +6,7 @@ import com.example.myapplication.board3d.BoardSquare
 import com.example.myapplication.board3d.Board3DSessionState
 import com.example.myapplication.persistence.GameActions
 import com.example.myapplication.persistence.GameHistoryRepository
+import com.example.myapplication.persistence.LocalAppSettings
 import com.example.myapplication.share.PgnSharer
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
@@ -42,8 +43,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -87,7 +86,6 @@ import game.app.generated.resources.decline_button
 import game.app.generated.resources.draw_offer_declined
 import game.app.generated.resources.draw_offer_prompt
 import game.app.generated.resources.offer_draw_button
-import game.app.generated.resources.board_3d_toggle_label
 import game.app.generated.resources.board_3d_unavailable
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -146,11 +144,44 @@ fun GameScreen(
     val animState by viewModel.animState.collectAsState()
     val viewState by viewModel.viewState.collectAsState()
     val scrollState = rememberScrollState()
+    // The 3D toggle now lives in SettingsScreen and writes to AppSettings.board3DEnabled. Observe it
+    // here (when a settings instance is provided via LocalAppSettings — production always provides
+    // one through AppRoot; tests that render GameScreen without AppRoot see `null` and fall back to
+    // the built-in default, 3D on) and re-run the entry/teardown frame choreography when it flips,
+    // so the loader/teardown overlays behave exactly as they did when the Switch was inline.
+    val appSettings = LocalAppSettings.current
+    val board3DEnabledFlow = remember(appSettings) {
+        appSettings?.board3DEnabled ?: kotlinx.coroutines.flow.MutableStateFlow(true)
+    }
+    val board3DEnabled by board3DEnabledFlow.collectAsState()
     val show3D = viewState.show3D && board3D != null
     val board3DCameraSession = remember { Board3DSessionState() }
     var isEntering3D by remember { mutableStateOf(false) }
     var isTearingDown3D by remember { mutableStateOf(false) }
     val coroutineScope = androidx.compose.runtime.rememberCoroutineScope()
+
+    // Bridge the persisted setting → the VM's runtime show3D flag, preserving the exact frame
+    // choreography the old inline Switch used (teardown holds the surface for two frames while the
+    // loader paints; enter gives the surface one frame before mounting). Skipped when there's no
+    // 3D backend or the value didn't actually change relative to current runtime state.
+    LaunchedEffect(board3DEnabled, board3D != null) {
+        if (board3D == null) return@LaunchedEffect
+        if (board3DEnabled && !viewState.show3D) {
+            // Enter 3D.
+            isEntering3D = true
+            withFrameNanos { }
+            viewModel.setShow3D(true)
+            // isEntering3D is cleared by Board3D's onRendererReady/onUnavailable callbacks.
+        } else if (!board3DEnabled && viewState.show3D) {
+            // Tear down 3D. Keep the existing surface mounted while the teardown overlay paints.
+            isTearingDown3D = true
+            withFrameNanos { }
+            withFrameNanos { }
+            viewModel.setShow3D(false)
+            withFrameNanos { }
+            isTearingDown3D = false
+        }
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (gameState.winState != WinState.NONE && !viewState.hideWindow) {
@@ -392,8 +423,7 @@ fun GameScreen(
                 .offset(y = switchTopPadding)
                 .padding(start = 12.dp, end = 8.dp, top = 4.dp, bottom = 4.dp)
         ) {
-            // Settings + History entry points (issue #39). Always visible; the rest of this row
-            // (the 3D toggle) only shows when a 3D backend is injected.
+            // Settings + History entry points (issue #39). The 3D toggle moved to SettingsScreen.
             TextButton(
                 onClick = onOpenSettings,
                 modifier = Modifier.testTag("open_settings_button")
@@ -413,57 +443,6 @@ fun GameScreen(
                     text = "History",
                     color = THREE_D_CONTROL_ACCENT_COLOR,
                     style = MaterialTheme.typography.labelLarge
-                )
-            }
-            if (board3D != null) {
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = stringResource(Res.string.board_3d_toggle_label),
-                    color = THREE_D_CONTROL_ACCENT_COLOR,
-                    style = MaterialTheme.typography.labelLarge
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Switch(
-                    checked = viewState.show3D,
-                    onCheckedChange = { checked ->
-                        if (!checked && viewState.show3D) {
-                            isTearingDown3D = true
-                            coroutineScope.launch {
-                                // Keep the existing surface mounted while Compose presents the
-                                // loader. Frame boundaries guarantee visible progress without a
-                                // timing guess; the second frame lets its animation advance before
-                                // SceneView/Filament teardown can occupy the UI thread.
-                                withFrameNanos { }
-                                withFrameNanos { }
-                                viewModel.setShow3D(false)
-                                // Disposal/recomposition has completed before controls re-enable.
-                                withFrameNanos { }
-                                isTearingDown3D = false
-                            }
-                        } else {
-                            isEntering3D = checked
-                            coroutineScope.launch {
-                                withFrameNanos { }
-                                viewModel.setShow3D(checked)
-                            }
-                        }
-                    },
-                    enabled = !viewState.buttonLock && !isEntering3D && !isTearingDown3D,
-                    colors = SwitchDefaults.colors(
-                        checkedThumbColor = THREE_D_CONTROL_CONTENT_COLOR,
-                        checkedTrackColor = THREE_D_CONTROL_CONTAINER_COLOR,
-                        checkedBorderColor = THREE_D_CONTROL_ACCENT_COLOR,
-                        uncheckedThumbColor = THREE_D_CONTROL_CONTENT_COLOR,
-                        uncheckedTrackColor = THREE_D_CONTROL_CONTAINER_COLOR,
-                        uncheckedBorderColor = THREE_D_CONTROL_ACCENT_COLOR,
-                        disabledCheckedThumbColor = THREE_D_CONTROL_DISABLED_CONTENT_COLOR,
-                        disabledCheckedTrackColor = THREE_D_CONTROL_CONTAINER_COLOR,
-                        disabledCheckedBorderColor = THREE_D_CONTROL_DISABLED_ACCENT_COLOR,
-                        disabledUncheckedThumbColor = THREE_D_CONTROL_DISABLED_CONTENT_COLOR,
-                        disabledUncheckedTrackColor = THREE_D_CONTROL_CONTAINER_COLOR,
-                        disabledUncheckedBorderColor = THREE_D_CONTROL_DISABLED_ACCENT_COLOR,
-                    ),
-                    modifier = Modifier.testTag("board_3d_toggle")
                 )
             }
         }

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
@@ -14,7 +14,8 @@ import kotlinx.coroutines.launch
 
 class GameViewModel(
     gameState: GameUiState = GameUiState(),
-    private val currentGameStore: CurrentGameStore? = null
+    private val currentGameStore: CurrentGameStore? = null,
+    initialShow3D: Boolean = true,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -30,7 +31,9 @@ class GameViewModel(
     private val _animState = MutableStateFlow(PieceAnimationState())
     val animState: StateFlow<PieceAnimationState> = _animState
 
-    private val _viewState = MutableStateFlow(ViewState())
+    // Seeded from the persisted AppSettings.board3DEnabled at construction (entry points pass it in).
+    // GameScreen re-runs its 3D entry/teardown choreography whenever AppSettings.board3DEnabled flips.
+    private val _viewState = MutableStateFlow(ViewState(show3D = initialShow3D))
     val viewState: StateFlow<ViewState> = _viewState
 
     private var gameMoves: Job? = null
@@ -74,13 +77,6 @@ class GameViewModel(
     fun hideWindow() {
         _viewState.value = viewState.value.copy(buttonLock = true, hideWindow = true)
     }
-
-    data class GameViewState(
-        val hideWindow: Boolean = false,
-        val show3D: Boolean = false,
-        val buttonLock: Boolean = false,
-        val board3DUnavailable: Boolean = false
-    )
 
     fun setShow3D(enabled: Boolean) {
         _viewState.value = viewState.value.copy(show3D = enabled, board3DUnavailable = false)

--- a/app/src/commonMain/kotlin/com/example/myapplication/SettingsScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/SettingsScreen.kt
@@ -1,24 +1,66 @@
 package com.example.myapplication
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import com.example.myapplication.board3d.Board3DSupport
+import com.example.myapplication.persistence.LocalAppSettings
+import game.app.generated.resources.Res
+import game.app.generated.resources.board_3d_toggle_label
+import org.jetbrains.compose.resources.stringResource
 
 /**
- * Settings screen. Currently a placeholder — the persisted theme selector was removed (theme now
- * always follows the system dark-mode setting). Engine difficulty (Phase 4) will slot in here,
- * reading and writing [com.example.myapplication.persistence.AppSettings] via [LocalAppSettings].
+ * Settings screen. Currently a placeholder for engine difficulty (Phase 4) plus the 3D-board on/off
+ * toggle, both reading and writing [com.example.myapplication.persistence.AppSettings] via
+ * [LocalAppSettings]. The persisted theme selector was removed (theme now always follows the system
+ * dark-mode setting).
+ *
+ * The 3D toggle is only shown when a [Board3DSupport] backend is available (`board3D != null`);
+ * platforms without one never show a dead control. Toggling it writes to `AppSettings.board3DEnabled`,
+ * which `GameScreen` observes and translates into the 3D surface mount/teardown choreography.
  */
 @Composable
-fun SettingsScreen(onBack: () -> Unit) {
+fun SettingsScreen(
+    onBack: () -> Unit,
+    board3D: Board3DSupport? = null,
+) {
+    val settings = LocalAppSettings.current
+        ?: error("SettingsScreen requires AppSettings. Render it under AppRoot.")
+    val board3DEnabled by settings.board3DEnabled.collectAsState()
+
     SubScreenScaffold(title = "Settings", onBack = onBack) {
         Text(
             text = "No settings yet. Engine difficulty will appear here.",
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.padding(top = 8.dp),
         )
+
+        if (board3D != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp, bottom = 4.dp)
+                    .testTag("settings_board_3d"),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Switch(
+                    checked = board3DEnabled,
+                    onCheckedChange = settings::setBoard3DEnabled,
+                )
+                Text(stringResource(Res.string.board_3d_toggle_label))
+            }
+        }
     }
 }

--- a/app/src/commonMain/kotlin/com/example/myapplication/persistence/AppSettings.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/persistence/AppSettings.kt
@@ -1,6 +1,8 @@
 package com.example.myapplication.persistence
 
 import com.russhwolf.settings.Settings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Typed, observable view over a russhwolf [Settings] instance. Plain class (mirrors
@@ -8,9 +10,29 @@ import com.russhwolf.settings.Settings
  * platform entry point and threaded into `AppRoot`. Holds [MutableStateFlow]s seeded from settings
  * and writes through on every setter.
  *
- * Currently empty — the persisted theme override was removed (theme now always follows the system
- * dark-mode setting). Engine difficulty (Phase 4) will reuse this class and its `Settings` backing
- * store. Kept as the injection seam for [LocalAppSettings] so the upcoming setting slots in without
- * rewiring the entry points.
+ * Surface: 3D-board-enabled toggle. The persisted theme override was removed (theme now always
+ * follows the system dark-mode setting). Engine difficulty (Phase 4) will reuse the same pattern.
  */
-class AppSettings(private val settings: Settings)
+class AppSettings(private val settings: Settings) {
+
+    /**
+     * Whether the 3D board is shown (vs the 2D board). Defaults to `true` on first install. Read by
+     * `SettingsScreen`'s Switch and observed by `GameScreen` to drive the mount/teardown of the 3D
+     * surface. The runtime `viewState.show3D` in [GameViewModel] is seeded from this value at
+     * construction; toggling it re-runs GameScreen's entry/teardown frame choreography.
+     */
+    private val _board3DEnabled: MutableStateFlow<Boolean> =
+        MutableStateFlow(readBoard3DEnabled())
+    val board3DEnabled: StateFlow<Boolean> get() = _board3DEnabled
+
+    fun setBoard3DEnabled(enabled: Boolean) {
+        settings.putBoolean(KEY_BOARD_3D, enabled)
+        _board3DEnabled.value = enabled
+    }
+
+    private fun readBoard3DEnabled(): Boolean = settings.getBoolean(KEY_BOARD_3D, true)
+
+    companion object {
+        const val KEY_BOARD_3D = "settings.board_3d_enabled"
+    }
+}

--- a/app/src/commonMain/kotlin/com/example/myapplication/persistence/LocalAppSettings.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/persistence/LocalAppSettings.kt
@@ -3,9 +3,13 @@ package com.example.myapplication.persistence
 import androidx.compose.runtime.staticCompositionLocalOf
 
 /**
- * Provides the app-wide [AppSettings] to deeply-nested composables (e.g. [SettingsScreen]) without
- * prop-drilling. Installed by [com.example.myapplication.AppRoot].
+ * Provides the app-wide [AppSettings] to deeply-nested composables (e.g. [SettingsScreen],
+ * [GameScreen]'s 3D-toggle observer) without prop-drilling. Installed by
+ * [com.example.myapplication.AppRoot].
+ *
+ * Defaults to `null` rather than throwing so that composables that read it (notably `GameScreen`,
+ * which observes `board3DEnabled`) can be rendered in tests without wrapping in `AppRoot` — those
+ * call sites treat `null` as "no setting provided" and fall back to the built-in default (3D on).
+ * Production code always runs under `AppRoot`, which provides a real instance.
  */
-val LocalAppSettings = staticCompositionLocalOf<AppSettings> {
-    error("AppSettings not provided. Wrap content in AppRoot or CompositionLocalProvider(LocalAppSettings provides ...).")
-}
+val LocalAppSettings = staticCompositionLocalOf<AppSettings?> { null }

--- a/app/src/commonTest/kotlin/com/example/myapplication/persistence/AppSettingsTest.kt
+++ b/app/src/commonTest/kotlin/com/example/myapplication/persistence/AppSettingsTest.kt
@@ -1,0 +1,36 @@
+package com.example.myapplication.persistence
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppSettingsTest {
+
+    @Test
+    fun `board3DEnabled defaults to true on first install`() {
+        val settings = AppSettings(MapSettings())
+        assertEquals(true, settings.board3DEnabled.value)
+    }
+
+    @Test
+    fun `setBoard3DEnabled round-trips through Settings`() {
+        val backing = MapSettings()
+        val settings = AppSettings(backing)
+
+        settings.setBoard3DEnabled(false)
+        assertEquals(false, settings.board3DEnabled.value)
+        assertEquals(false, backing.getBoolean(AppSettings.KEY_BOARD_3D, true))
+
+        // A fresh AppSettings over the same backing reads the persisted value.
+        val reloaded = AppSettings(backing)
+        assertEquals(false, reloaded.board3DEnabled.value)
+    }
+
+    @Test
+    fun `setBoard3DEnabled updates the StateFlow`() {
+        val settings = AppSettings(MapSettings())
+        settings.setBoard3DEnabled(false)
+        assertEquals(false, settings.board3DEnabled.value)
+        settings.setBoard3DEnabled(true)
+        assertEquals(true, settings.board3DEnabled.value)
+    }
+}

--- a/app/src/desktopMain/kotlin/com/example/myapplication/Main.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/Main.kt
@@ -29,11 +29,14 @@ fun main() = application {
         if (restoredState.shouldClear) currentGameStore.clear()
         onDispose { }
     }
-    val viewModel = remember { GameViewModel(restoredState.state, currentGameStore) }
-    val board3D = remember { desktopBoard3DSupport() }
     val appSettings = remember { AppSettings(settings) }
     val gameHistory = remember { GameHistoryRepository(settings) }
     val pgnSharer = remember { desktopPgnSharer() }
+    val viewModel = remember {
+        // Seed the VM's runtime show3D from the persisted setting (3D on by default).
+        GameViewModel(restoredState.state, currentGameStore, initialShow3D = appSettings.board3DEnabled.value)
+    }
+    val board3D = remember { desktopBoard3DSupport() }
 
     DisposableEffect(Unit) {
         val engine = DesktopStockfishEngine()

--- a/app/src/desktopTest/kotlin/com/example/myapplication/board3d/Board3DUiTest.kt
+++ b/app/src/desktopTest/kotlin/com/example/myapplication/board3d/Board3DUiTest.kt
@@ -1,47 +1,72 @@
 package com.example.myapplication.board3d
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import com.example.myapplication.GameScreen
 import com.example.myapplication.GameViewModel
 import com.example.myapplication.WindowWidthSizeClass
+import com.example.myapplication.persistence.AppSettings
+import com.example.myapplication.persistence.LocalAppSettings
+import com.example.myapplication.persistence.MapSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+/**
+ * Wraps `GameScreen` content with a `LocalAppSettings` so the screen's read of
+ * `AppSettings.board3DEnabled` resolves (GameScreen observes the persisted 3D setting to drive its
+ * mount/teardown choreography). Returns the [AppSettings] so tests can drive the toggle via the
+ * real setting path (`setBoard3DEnabled`), which is what fires the entry/teardown `LaunchedEffect`.
+ */
+@OptIn(ExperimentalTestApi::class)
+private fun androidx.compose.ui.test.ComposeUiTest.wrapGame(
+    viewModel: GameViewModel,
+    support: Board3DSupport,
+): AppSettings {
+    val appSettings = AppSettings(MapSettings())
+    setContent {
+        CompositionLocalProvider(LocalAppSettings provides appSettings) {
+            GameScreen(WindowWidthSizeClass.Medium, viewModel, support)
+        }
+    }
+    return appSettings
+}
+
 @OptIn(ExperimentalTestApi::class)
 class Board3DUiTest {
+
+    private fun fakeSupport(renderer: FakeChess3DRenderer) = Board3DSupport(
+        rendererFactory = { renderer },
+        surfaceContent = { r, modifier ->
+            androidx.compose.runtime.DisposableEffect(r) {
+                r.attach(FakeChess3DSurface())
+                onDispose { r.detach() }
+            }
+            Box(modifier)
+        },
+    )
 
     @Test
     fun teardownLoaderIsVisibleBeforeRendererDisposal() = runComposeUiTest {
         val fakeRenderer = FakeChess3DRenderer()
-        val support = Board3DSupport(
-            rendererFactory = { fakeRenderer },
-            surfaceContent = { renderer, modifier ->
-                androidx.compose.runtime.DisposableEffect(renderer) {
-                    renderer.attach(FakeChess3DSurface())
-                    onDispose { renderer.detach() }
-                }
-                Box(modifier)
-            },
-        )
         val viewModel = GameViewModel()
         mainClock.autoAdvance = false
 
-        setContent {
-            GameScreen(WindowWidthSizeClass.Medium, viewModel, support)
-        }
+        val appSettings = wrapGame(viewModel, fakeSupport(fakeRenderer))
         mainClock.advanceTimeByFrame()
         mainClock.advanceTimeByFrame()
 
-        onNodeWithTag("board_3d_toggle").performClick()
+        // Toggle 3D off via the persisted setting (the on-screen Switch moved to SettingsScreen;
+        // GameScreen's LaunchedEffect reacts to board3DEnabled and runs the teardown frames). The
+        // effect relaunch needs a frame, then its first statement sets isTearingDown3D=true.
+        appSettings.setBoard3DEnabled(false)
+        mainClock.advanceTimeByFrame()
         mainClock.advanceTimeByFrame()
 
-        onNodeWithTag("board_3d_tearing_down").assertExists()
+        assertTrue(onAllNodesWithTag("board_3d_tearing_down").fetchSemanticsNodes().isNotEmpty())
         assertEquals(0, fakeRenderer.events.count { it == "dispose" })
 
         mainClock.advanceTimeByFrame()
@@ -54,29 +79,10 @@ class Board3DUiTest {
     @Test
     fun test3DToggleAndFallback() = runComposeUiTest {
         val fakeRenderer = FakeChess3DRenderer()
-        val board3DSupport = Board3DSupport(
-            rendererFactory = { fakeRenderer },
-            surfaceContent = { renderer, modifier -> 
-                androidx.compose.runtime.DisposableEffect(renderer) {
-                    val fakeSurface = FakeChess3DSurface()
-                    renderer.attach(fakeSurface)
-                    onDispose {
-                        renderer.detach()
-                    }
-                }
-                Box(modifier) 
-            }
-        )
-
         val viewModel = GameViewModel()
 
-        setContent {
-            GameScreen(
-                windowSize = WindowWidthSizeClass.Medium,
-                viewModel = viewModel,
-                board3D = board3DSupport
-            )
-        }
+        val appSettings = wrapGame(viewModel, fakeSupport(fakeRenderer))
+        waitForIdle()
 
         // Initially 3D board is shown, 2D is not
         assertTrue(onAllNodesWithTag("board_3d").fetchSemanticsNodes().isNotEmpty())
@@ -85,8 +91,8 @@ class Board3DUiTest {
         // Verify renderer was attached
         assertEquals(1, fakeRenderer.events.count { it == "attach" })
 
-        // Toggle 3D off
-        viewModel.setShow3D(false)
+        // Toggle 3D off (via the setting → GameScreen's reactive bridge)
+        appSettings.setBoard3DEnabled(false)
         waitForIdle()
 
         // 2D board should be shown, 3D board should NOT be shown
@@ -98,13 +104,13 @@ class Board3DUiTest {
         assertEquals(1, fakeRenderer.events.count { it == "dispose" })
 
         // Toggle 3D on again
-        viewModel.setShow3D(true)
+        appSettings.setBoard3DEnabled(true)
         waitForIdle()
 
         // 3D back, 2D gone
         assertTrue(onAllNodesWithTag("board_3d").fetchSemanticsNodes().isNotEmpty())
         assertTrue(onAllNodesWithTag("chess_board").fetchSemanticsNodes().isEmpty())
-        
+
         // Verify renderer was attached again
         assertEquals(2, fakeRenderer.events.count { it == "attach" })
     }
@@ -117,17 +123,14 @@ class Board3DUiTest {
         )
 
         val viewModel = GameViewModel()
+        val appSettings = wrapGame(viewModel, board3DSupport)
+        waitForIdle()
 
-        setContent {
-            GameScreen(
-                windowSize = WindowWidthSizeClass.Medium,
-                viewModel = viewModel,
-                board3D = board3DSupport
-            )
-        }
-
-        // Toggle 3D on
-        viewModel.setShow3D(true)
+        // Toggle 3D on (the setting starts true; force a flip-flop so the enter effect re-fires
+        // against the failing factory).
+        appSettings.setBoard3DEnabled(false)
+        waitForIdle()
+        appSettings.setBoard3DEnabled(true)
         waitForIdle()
 
         // 2D board is still shown
@@ -141,28 +144,9 @@ class Board3DUiTest {
     @Test
     fun test3DAnimationDelivery() = runComposeUiTest {
         val fakeRenderer = FakeChess3DRenderer()
-        val board3DSupport = Board3DSupport(
-            rendererFactory = { fakeRenderer },
-            surfaceContent = { renderer, modifier -> 
-                androidx.compose.runtime.DisposableEffect(renderer) {
-                    val fakeSurface = FakeChess3DSurface()
-                    renderer.attach(fakeSurface)
-                    onDispose { renderer.detach() }
-                }
-                Box(modifier) 
-            }
-        )
-
         val viewModel = GameViewModel()
 
-        setContent {
-            GameScreen(
-                windowSize = WindowWidthSizeClass.Medium,
-                viewModel = viewModel,
-                board3D = board3DSupport
-            )
-        }
-
+        wrapGame(viewModel, fakeSupport(fakeRenderer))
         waitForIdle()
         fakeRenderer.events.clear()
 
@@ -171,11 +155,11 @@ class Board3DUiTest {
         val e4 = Pair(4, 4)
         viewModel.updateSelected(e2)
         waitForIdle()
-        
+
         // Find index of pawn at e2
         val state = viewModel.gameState.value
         val index = state.positionsWhite.indexOf(e2)
-        
+
         viewModel.playerMove(index, e4)
         waitForIdle()
 
@@ -184,3 +168,4 @@ class Board3DUiTest {
         assertTrue(animationEvents.isNotEmpty(), "Expected at least one animated updatePosition event")
     }
 }
+

--- a/app/src/iosMain/kotlin/com/example/myapplication/MainViewController.kt
+++ b/app/src/iosMain/kotlin/com/example/myapplication/MainViewController.kt
@@ -35,10 +35,12 @@ fun MainViewController(
         if (restoredState.shouldClear) currentGameStore.clear()
         onDispose { }
     }
-    val viewModel = remember { GameViewModel(restoredState.state, currentGameStore) }
     val appSettings = remember { AppSettings(settings) }
     val gameHistory = remember { GameHistoryRepository(settings) }
     val pgnSharer = remember { iosPgnSharer() }
+    val viewModel = remember {
+        GameViewModel(restoredState.state, currentGameStore, initialShow3D = appSettings.board3DEnabled.value)
+    }
     DisposableEffect(Unit) {
         viewModel.attachEngine(engine)
         if (platform.posix.getenv("CHESS_START_3D") != null) viewModel.setShow3D(true)

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/Main.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/Main.kt
@@ -26,10 +26,12 @@ fun main() {
             if (restoredState.shouldClear) currentGameStore.clear()
             onDispose { }
         }
-        val viewModel = remember { GameViewModel(restoredState.state, currentGameStore) }
         val appSettings = remember { AppSettings(settings) }
         val gameHistory = remember { GameHistoryRepository(settings) }
         val pgnSharer = remember { wasmPgnSharer() }
+        val viewModel = remember {
+            GameViewModel(restoredState.state, currentGameStore, initialShow3D = appSettings.board3DEnabled.value)
+        }
         LaunchedEffect(Unit) {
             val engine = WasmStockfishEngine()
             if (engine.start()) {


### PR DESCRIPTION
Moves the 3D board on/off switch out of the `GameScreen` top bar and into `SettingsScreen`, persisted across restarts, defaulting to **3D on** on first install.

## What changed

- **`AppSettings`** — new persisted `board3DEnabled: StateFlow<Boolean>` + `setBoard3DEnabled()`, stored under `settings.board_3d_enabled`, default `true`.
- **`GameScreen`** — the inline `Switch` + label are removed from the top bar (only Settings + History buttons remain there). `GameScreen` now observes `AppSettings.board3DEnabled` (via `LocalAppSettings`); a `LaunchedEffect(board3DEnabled, board3D != null)` re-runs the **exact** entry/teardown frame choreography (`isEntering3D`/`isTearingDown3D` + `withFrameNanos`) when the setting flips — so the loader/teardown overlays behave identically to before, just triggered reactively instead of from an inline Switch callback.
- **`GameViewModel`** — new `initialShow3D` ctor param (default `true`); entry points seed it from `AppSettings.board3DEnabled.value`. Runtime `viewState.show3D` remains the 3D-surface mount signal. Deleted the dead nested `GameViewState` duplicate.
- **`SettingsScreen`** — adds a `Switch` for the 3D toggle (gated on `board3D != null`, so platforms without a backend don't show a dead control). `AppRoot` threads `board3D` into `SettingsScreen`.
- **`LocalAppSettings`** — changed from a throwing `staticCompositionLocalOf` to a nullable one (`null` default), so `GameScreen` can be rendered in tests without `AppRoot` (falls back to 3D on). `SettingsScreen` still requires it (errors if absent).

## The tricky part (and how it's preserved)
The old Switch's `onCheckedChange` wasn't a pure setter — it mutated GameScreen-local `isEntering3D`/`isTearingDown3D` flags and launched the `withFrameNanos` coroutines that drive the loader/teardown overlays. Moving the Switch off-screen means those flags aren't in scope where the toggle lives. The fix: the Settings Switch only writes the persisted flow; GameScreen observes it and **keeps** the entry/teardown choreography locally (keyed off the flow value changing). No behavioral change to the 3D mount/teardown UX.

## Tests
- `AppSettingsTest` — `board3DEnabled` defaults to `true`; round-trips through `Settings`; updates the `StateFlow`.
- `desktopTest Board3DUiTest` — rewired to drive the toggle via the persisted setting (`setBoard3DEnabled`) instead of the removed `board_3d_toggle` node, wrapped in `LocalAppSettings`. Validates the teardown overlay + enter/fallback paths still work through the new reactive bridge.
- Other 3D UI tests (wasm/ios/android) need no changes — `LocalAppSettings` defaulting to `null` lets them render `GameScreen` unwrapped (3D on by default), and they drive toggles via `viewModel.setShow3D` which still works.

## Verification
- `./gradlew :app:check` ✅ (Android host/target + wasm tests + iOS test compile — incl. all 3D UI tests)
- Full CI gate ✅ — `:androidApp:assembleDebug`, `:app:desktopJar`, `:app:packageDistributionForCurrentOS`, `:app:wasmJsBrowserDistribution`, `:app:assembleAndroidDeviceTest`

## Merge notes
Touches `AppSettings`, `SettingsScreen`, `GameScreen`, `LocalAppSettings`, and all entry points. Conflicts trivially (and additively) with #65 (history/save-share) and #66 (theme removal) on `AppSettings`/`SettingsScreen`/`GameViewModel` — any merge order resolves cleanly.