### PR TITLE
feat(lifecycle): engine difficulty (#39)

### DIFF
--- a/app/src/androidDeviceTest/kotlin/com/example/myapplication/EngineDifficultySettingsTest.kt
+++ b/app/src/androidDeviceTest/kotlin/com/example/myapplication/EngineDifficultySettingsTest.kt
@@ -1,0 +1,50 @@
+package com.example.myapplication
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.myapplication.persistence.AppSettings
+import com.example.myapplication.persistence.LocalAppSettings
+import com.russhwolf.settings.SharedPreferencesSettings
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Phase 4 instrumented test: changing the engine difficulty in Settings persists the value. Uses the
+ * real Android `SharedPreferences` backend; behavioural play strength is not asserted (too flaky).
+ */
+@RunWith(AndroidJUnit4::class)
+class EngineDifficultySettingsTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun tappingADifficultyOptionPersistsIt() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        val prefs = context.getSharedPreferences("chess_diff_test_${System.nanoTime()}", android.content.Context.MODE_PRIVATE)
+        val appSettings = AppSettings(SharedPreferencesSettings(prefs))
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalAppSettings provides appSettings) {
+                SettingsScreen(onBack = {}, board3D = null)
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        // Default is MEDIUM; tap HARD and assert it persisted.
+        assertEquals(EngineDifficulty.MEDIUM, appSettings.engineDifficulty.value)
+        composeTestRule.onNodeWithTag("settings_difficulty_HARD").performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(EngineDifficulty.HARD, appSettings.engineDifficulty.value)
+        // A fresh AppSettings over the same backing reads the persisted HARD value.
+        val reloaded = AppSettings(SharedPreferencesSettings(prefs))
+        assertEquals(EngineDifficulty.HARD, reloaded.engineDifficulty.value)
+    }
+}

--- a/app/src/androidMain/kotlin/com/example/myapplication/MainActivity.kt
+++ b/app/src/androidMain/kotlin/com/example/myapplication/MainActivity.kt
@@ -80,9 +80,14 @@ class AndroidGameViewModel : ViewModel() {
     private val settings = createSettings("chess")
     private val currentGameStore = CurrentGameStore(settings)
     private val restoredState = CurrentGameStoreSupport.loadInitialState(currentGameStore)
-    // Seed the VM's runtime show3D from the persisted setting (3D on by default on first install).
-    private val initialShow3D = AppSettings(settings).board3DEnabled.value
-    val gameViewModel = GameViewModel(restoredState.state, currentGameStore, initialShow3D = initialShow3D)
+    // Seed the VM's runtime show3D + engine difficulty from the persisted settings (first install:
+    // 3D on, MEDIUM difficulty).
+    private val appSettings = AppSettings(settings)
+    val gameViewModel = GameViewModel(
+        restoredState.state, currentGameStore,
+        initialShow3D = appSettings.board3DEnabled.value,
+        initialEngineDifficulty = appSettings.engineDifficulty.value,
+    )
 
     // Phase 3: saved-games history lives on the same Settings backing store, owned by the holder so
     // it survives config changes (and is observed by the History screen across recompositions).

--- a/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -56,6 +57,13 @@ fun AppRoot(
         MyApplicationTheme(darkTheme = isSystemInDarkTheme()) {
             var screen by rememberSaveable { mutableStateOf(Screen.GAME) }
             BackHandler(enabled = screen != Screen.GAME) { screen = Screen.GAME }
+
+            // Bridge the persisted engine-difficulty setting → the VM (issue #39 Phase 4). The VM
+            // seeds its initial value at construction; this forwards subsequent changes from
+            // SettingsScreen, applying them to the attached engine via setEngineDifficulty.
+            LaunchedEffect(Unit) {
+                settings.engineDifficulty.collect { viewModel.setEngineDifficulty(it) }
+            }
 
             when (screen) {
                 Screen.GAME -> ChessApp(

--- a/app/src/commonMain/kotlin/com/example/myapplication/ChessEngine.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/ChessEngine.kt
@@ -3,10 +3,17 @@ package com.example.myapplication
 interface ChessEngine {
     suspend fun getBestMove(fen: String): String?
     fun close()
-    
+
     /**
      * Position evaluation in centipawns from WHITE's perspective (positive = White better).
      * Mate-in-N maps to ±(100000 - N). Null = unavailable (callers fall back to material balance).
      */
     suspend fun evaluate(fen: String): Int? = null
+
+    /**
+     * Apply a play-strength setting (issue #39 Phase 4). Default no-op: the built-in CPU fallback
+     * (no `ChessEngine`) ignores it, and any engine that doesn't override it plays at default strength.
+     * Real engines override this to send `setoption name Skill Level` + adjust their movetime budget.
+     */
+    suspend fun configure(difficulty: EngineDifficulty) {}
 }

--- a/app/src/commonMain/kotlin/com/example/myapplication/EngineDifficulty.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/EngineDifficulty.kt
@@ -1,0 +1,16 @@
+package com.example.myapplication
+
+/**
+ * Engine play-strength setting (issue #39 Phase 4). Each level maps to:
+ *  - [skillLevel]: Stockfish `Skill Level` option (0–20), sent via `setoption name Skill Level value N`.
+ *  - [thinkTimeMs]: per-move `movetime` budget (ms) used in the `go movetime` command.
+ *
+ * Lower levels weaken play both by lowering Stockfish's skill and by giving it less time to think.
+ * The CPU fallback (no `ChessEngine` attached) ignores this — it always uses `pickMoveCPU`.
+ */
+enum class EngineDifficulty(val skillLevel: Int, val thinkTimeMs: Long) {
+    EASY(skillLevel = 2, thinkTimeMs = 200L),
+    MEDIUM(skillLevel = 8, thinkTimeMs = 500L),
+    HARD(skillLevel = 15, thinkTimeMs = 1000L),
+    MAX(skillLevel = 20, thinkTimeMs = 2000L);
+}

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
@@ -16,6 +16,7 @@ class GameViewModel(
     gameState: GameUiState = GameUiState(),
     private val currentGameStore: CurrentGameStore? = null,
     initialShow3D: Boolean = true,
+    initialEngineDifficulty: EngineDifficulty = EngineDifficulty.MEDIUM,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -39,6 +40,9 @@ class GameViewModel(
     private var gameMoves: Job? = null
     private var chessEngine: ChessEngine? = null
 
+    /** Current engine difficulty (issue #39 Phase 4). Applied to the engine on attach + on change. */
+    private var engineDifficulty: EngineDifficulty = initialEngineDifficulty
+
     /** `true` when a real engine (Stockfish) drives Black; `false` = built-in CPU fallback.
      *  Used for PGN player naming (issue #39 Phase 3: Black = "Stockfish" vs "CPU"). */
     val engineAttached: Boolean get() = chessEngine != null
@@ -50,10 +54,24 @@ class GameViewModel(
     fun attachEngine(engine: ChessEngine?) {
         chessEngine?.close()
         chessEngine = engine
+        // Apply the current difficulty to the new engine (issue #39 Phase 4). The default no-op
+        // configure() leaves the CPU fallback unaffected; real engines send the setoption.
+        applyDifficulty()
         // Resume-later: if the game was restored from autosave and it's Black's move, nudge the
         // turn-driven engine flow (mirrors `animationEnd()`'s Black branch). Skipped when there's
         // no engine (CPU fallback resumes lazily via `moveCPU`) or the game is already over.
         maybeResumeBlack()
+    }
+
+    /** Updates the engine difficulty and applies it to the attached engine (issue #39 Phase 4). */
+    fun setEngineDifficulty(difficulty: EngineDifficulty) {
+        engineDifficulty = difficulty
+        applyDifficulty()
+    }
+
+    private fun applyDifficulty() {
+        val engine = chessEngine ?: return
+        scope.launch { engine.configure(engineDifficulty) }
     }
 
     private fun maybeResumeBlack() {

--- a/app/src/commonMain/kotlin/com/example/myapplication/SettingsScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/SettingsScreen.kt
@@ -1,10 +1,13 @@
 package com.example.myapplication
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,14 +24,17 @@ import game.app.generated.resources.board_3d_toggle_label
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Settings screen. Currently a placeholder for engine difficulty (Phase 4) plus the 3D-board on/off
- * toggle, both reading and writing [com.example.myapplication.persistence.AppSettings] via
- * [LocalAppSettings]. The persisted theme selector was removed (theme now always follows the system
- * dark-mode setting).
+ * Settings screen. Holds the engine-difficulty selector and the 3D-board on/off toggle, both reading
+ * and writing [com.example.myapplication.persistence.AppSettings] via [LocalAppSettings]. The
+ * persisted theme selector was removed (theme now always follows the system dark-mode setting).
  *
  * The 3D toggle is only shown when a [Board3DSupport] backend is available (`board3D != null`);
  * platforms without one never show a dead control. Toggling it writes to `AppSettings.board3DEnabled`,
  * which `GameScreen` observes and translates into the 3D surface mount/teardown choreography.
+ *
+ * Difficulty is always visible — it applies to the engine on every platform (the CPU fallback ignores
+ * it, but the setting persists for when an engine is attached). `AppRoot` bridges the setting to the
+ * VM's `setEngineDifficulty`, which applies it to the attached engine.
  */
 @Composable
 fun SettingsScreen(
@@ -38,13 +44,25 @@ fun SettingsScreen(
     val settings = LocalAppSettings.current
         ?: error("SettingsScreen requires AppSettings. Render it under AppRoot.")
     val board3DEnabled by settings.board3DEnabled.collectAsState()
+    val engineDifficulty by settings.engineDifficulty.collectAsState()
 
     SubScreenScaffold(title = "Settings", onBack = onBack) {
         Text(
-            text = "No settings yet. Engine difficulty will appear here.",
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(top = 8.dp),
+            text = "Engine difficulty",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
         )
+        Column(modifier = Modifier.fillMaxWidth().selectableGroup()) {
+            EngineDifficulty.entries.forEach { level ->
+                DifficultyOption(
+                    label = level.name.lowercase().replaceFirstChar { it.titlecase() },
+                    level = level,
+                    current = engineDifficulty,
+                    onSelect = settings::setEngineDifficulty,
+                    testTag = "settings_difficulty_${level.name}",
+                )
+            }
+        }
 
         if (board3D != null) {
             Row(
@@ -62,5 +80,29 @@ fun SettingsScreen(
                 Text(stringResource(Res.string.board_3d_toggle_label))
             }
         }
+    }
+}
+
+@Composable
+private fun DifficultyOption(
+    label: String,
+    level: EngineDifficulty,
+    current: EngineDifficulty,
+    onSelect: (EngineDifficulty) -> Unit,
+    testTag: String,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .testTag(testTag),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        RadioButton(
+            selected = current == level,
+            onClick = { onSelect(level) },
+        )
+        Text(label)
     }
 }

--- a/app/src/commonMain/kotlin/com/example/myapplication/SettingsScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/SettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -16,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.example.myapplication.board3d.Board3DSupport
 import com.example.myapplication.persistence.LocalAppSettings
@@ -94,6 +96,11 @@ private fun DifficultyOption(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .selectable(
+                selected = current == level,
+                role = Role.RadioButton,
+                onClick = { onSelect(level) },
+            )
             .padding(vertical = 4.dp)
             .testTag(testTag),
         verticalAlignment = Alignment.CenterVertically,
@@ -101,7 +108,7 @@ private fun DifficultyOption(
     ) {
         RadioButton(
             selected = current == level,
-            onClick = { onSelect(level) },
+            onClick = null,
         )
         Text(label)
     }

--- a/app/src/commonMain/kotlin/com/example/myapplication/UciProtocolClient.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/UciProtocolClient.kt
@@ -19,6 +19,11 @@ class UciProtocolClient(private val transport: UciTransport) {
     private val mutex = Mutex()
     private var isReady = false
 
+    // Engine difficulty (issue #39 Phase 4). `null` skillLevel = unset; movetime defaults to the
+    // classic think budget. configure() sends `setoption name Skill Level value N` + an isready sync.
+    private var skillLevel: Int? = null
+    private var thinkTimeMs: Long = DEFAULT_THINK_TIME_MS
+
     suspend fun start(timeoutMs: Long = HANDSHAKE_TIMEOUT_MS): Boolean = mutex.withLock {
         if (isReady) return true
         transport.start { line -> incoming.trySend(line) }
@@ -27,10 +32,30 @@ class UciProtocolClient(private val transport: UciTransport) {
         transport.send("isready")
         if (!awaitLinePrefix("readyok", timeoutMs)) return false
         isReady = true
+        // Apply any difficulty configured before start (so it takes effect on the first move).
+        skillLevel?.let { applySkillLevel(it) }
         true
     }
 
-    suspend fun bestMove(fen: String, thinkTimeMs: Long = DEFAULT_THINK_TIME_MS): String? = mutex.withLock {
+    /**
+     * Applies [difficulty]'s Stockfish `Skill Level` (sent as `setoption`) and stores its movetime
+     * budget for subsequent `go movetime` calls. No-op-friendly: safe to call before [start] (the
+     * option is applied once the engine is ready) or after (sent immediately). Mirrors the handshake's
+     * isready-sync so the option is committed before the next `go`.
+     */
+    suspend fun configure(difficulty: EngineDifficulty) = mutex.withLock {
+        skillLevel = difficulty.skillLevel
+        thinkTimeMs = difficulty.thinkTimeMs
+        if (isReady) applySkillLevel(difficulty.skillLevel)
+    }
+
+    private suspend fun applySkillLevel(level: Int) {
+        transport.send("setoption name Skill Level value $level")
+        transport.send("isready")
+        awaitLinePrefix("readyok", REPLY_GRACE_MS)
+    }
+
+    suspend fun bestMove(fen: String, thinkTimeMs: Long = this.thinkTimeMs): String? = mutex.withLock {
         if (!isReady) return null
         drainPending()
         transport.send("position fen $fen")

--- a/app/src/commonMain/kotlin/com/example/myapplication/persistence/AppSettings.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/persistence/AppSettings.kt
@@ -1,5 +1,6 @@
 package com.example.myapplication.persistence
 
+import com.example.myapplication.EngineDifficulty
 import com.russhwolf.settings.Settings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -10,8 +11,8 @@ import kotlinx.coroutines.flow.StateFlow
  * platform entry point and threaded into `AppRoot`. Holds [MutableStateFlow]s seeded from settings
  * and writes through on every setter.
  *
- * Surface: 3D-board-enabled toggle. The persisted theme override was removed (theme now always
- * follows the system dark-mode setting). Engine difficulty (Phase 4) will reuse the same pattern.
+ * Surface: 3D-board-enabled toggle + engine difficulty. The persisted theme override was removed
+ * (theme now always follows the system dark-mode setting).
  */
 class AppSettings(private val settings: Settings) {
 
@@ -32,7 +33,28 @@ class AppSettings(private val settings: Settings) {
 
     private fun readBoard3DEnabled(): Boolean = settings.getBoolean(KEY_BOARD_3D, true)
 
+    /**
+     * Engine play-strength (issue #39 Phase 4). Defaults to [EngineDifficulty.MEDIUM]. Read by
+     * `SettingsScreen`'s radio group; applied to the attached engine via
+     * [com.example.myapplication.GameViewModel.attachEngine]/`setEngineDifficulty`.
+     */
+    private val _engineDifficulty: MutableStateFlow<EngineDifficulty> =
+        MutableStateFlow(readEngineDifficulty())
+    val engineDifficulty: StateFlow<EngineDifficulty> get() = _engineDifficulty
+
+    fun setEngineDifficulty(difficulty: EngineDifficulty) {
+        settings.putString(KEY_ENGINE_DIFFICULTY, difficulty.name)
+        _engineDifficulty.value = difficulty
+    }
+
+    private fun readEngineDifficulty(): EngineDifficulty =
+        settings.getStringOrNull(KEY_ENGINE_DIFFICULTY)
+            ?.let { runCatching { EngineDifficulty.valueOf(it) }.getOrNull() }
+            ?: EngineDifficulty.MEDIUM
+
     companion object {
         const val KEY_BOARD_3D = "settings.board_3d_enabled"
+        const val KEY_ENGINE_DIFFICULTY = "settings.engine_difficulty"
     }
 }
+

--- a/app/src/commonTest/kotlin/com/example/myapplication/UciProtocolClientTest.kt
+++ b/app/src/commonTest/kotlin/com/example/myapplication/UciProtocolClientTest.kt
@@ -88,21 +88,77 @@ class UciProtocolClientTest {
     fun `evaluate parsing`() = runTest {
         val transport = FakeUciTransport()
         val client = UciProtocolClient(transport)
-        
+
         val startJob = async { client.start() }
         runCurrent()
         transport.onLine?.invoke("uciok")
         runCurrent()
         transport.onLine?.invoke("readyok")
         startJob.await()
-        
+
         // White to move, eval 50 -> returns 50
         val evalJob = async { client.evaluate("... w ...") }
         runCurrent()
-        
+
         transport.onLine?.invoke("info score cp 50")
         transport.onLine?.invoke("bestmove e2e4") // must trigger completion
-        
+
         assertEquals(50, evalJob.await())
+    }
+
+    // --- Engine difficulty (issue #39 Phase 4) ---
+
+    @Test
+    fun `configure sends setoption Skill Level and isready sync`() = runTest {
+        val transport = FakeUciTransport()
+        val client = UciProtocolClient(transport)
+
+        val startJob = async { client.start() }
+        runCurrent()
+        transport.onLine?.invoke("uciok")
+        runCurrent()
+        transport.onLine?.invoke("readyok")
+        startJob.await()
+
+        transport.commands.clear()
+        val configureJob = async { client.configure(EngineDifficulty.EASY) }
+        runCurrent()
+
+        // Skill Level 2 for EASY, then the isready sync.
+        assertTrue(transport.commands.contains("setoption name Skill Level value 2"))
+        assertEquals("isready", transport.commands.last())
+        transport.onLine?.invoke("readyok")
+        runCurrent()
+        configureJob.await()
+    }
+
+    @Test
+    fun `bestMove uses the configured difficulty movetime`() = runTest {
+        val transport = FakeUciTransport()
+        val client = UciProtocolClient(transport)
+
+        val startJob = async { client.start() }
+        runCurrent()
+        transport.onLine?.invoke("uciok")
+        runCurrent()
+        transport.onLine?.invoke("readyok")
+        startJob.await()
+
+        // EASY = 200ms movetime. Configure, then bestMove should use it (not the default 1000ms).
+        val configureJob = async { client.configure(EngineDifficulty.EASY) }
+        runCurrent()
+        transport.onLine?.invoke("readyok")  // satisfy the isready sync from configure
+        runCurrent()
+        configureJob.await()
+
+        transport.commands.clear()
+        val fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        val moveJob = async { client.bestMove(fen) }
+        runCurrent()
+
+        assertEquals("go movetime 200", transport.commands.last { it.startsWith("go movetime") })
+
+        transport.onLine?.invoke("bestmove e2e4")
+        assertEquals("e2e4", moveJob.await())
     }
 }

--- a/app/src/commonTest/kotlin/com/example/myapplication/persistence/AppSettingsTest.kt
+++ b/app/src/commonTest/kotlin/com/example/myapplication/persistence/AppSettingsTest.kt
@@ -1,5 +1,6 @@
 package com.example.myapplication.persistence
 
+import com.example.myapplication.EngineDifficulty
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -32,5 +33,43 @@ class AppSettingsTest {
         assertEquals(false, settings.board3DEnabled.value)
         settings.setBoard3DEnabled(true)
         assertEquals(true, settings.board3DEnabled.value)
+    }
+
+    // --- engineDifficulty (issue #39 Phase 4) ---
+
+    @Test
+    fun `engineDifficulty defaults to MEDIUM`() {
+        val settings = AppSettings(MapSettings())
+        assertEquals(EngineDifficulty.MEDIUM, settings.engineDifficulty.value)
+    }
+
+    @Test
+    fun `setEngineDifficulty round-trips through Settings`() {
+        val backing = MapSettings()
+        val settings = AppSettings(backing)
+
+        settings.setEngineDifficulty(EngineDifficulty.HARD)
+        assertEquals(EngineDifficulty.HARD, settings.engineDifficulty.value)
+        assertEquals(EngineDifficulty.HARD.name, backing.getStringOrNull(AppSettings.KEY_ENGINE_DIFFICULTY))
+
+        // A fresh AppSettings over the same backing reads the persisted value.
+        val reloaded = AppSettings(backing)
+        assertEquals(EngineDifficulty.HARD, reloaded.engineDifficulty.value)
+    }
+
+    @Test
+    fun `unknown stored difficulty falls back to MEDIUM without throwing`() {
+        val backing = MapSettings().apply { putString(AppSettings.KEY_ENGINE_DIFFICULTY, "NIGHTMARE") }
+        val settings = AppSettings(backing)
+        assertEquals(EngineDifficulty.MEDIUM, settings.engineDifficulty.value)
+    }
+
+    @Test
+    fun `setEngineDifficulty updates the StateFlow`() {
+        val settings = AppSettings(MapSettings())
+        settings.setEngineDifficulty(EngineDifficulty.EASY)
+        assertEquals(EngineDifficulty.EASY, settings.engineDifficulty.value)
+        settings.setEngineDifficulty(EngineDifficulty.MAX)
+        assertEquals(EngineDifficulty.MAX, settings.engineDifficulty.value)
     }
 }

--- a/app/src/desktopMain/kotlin/com/example/myapplication/Main.kt
+++ b/app/src/desktopMain/kotlin/com/example/myapplication/Main.kt
@@ -33,8 +33,12 @@ fun main() = application {
     val gameHistory = remember { GameHistoryRepository(settings) }
     val pgnSharer = remember { desktopPgnSharer() }
     val viewModel = remember {
-        // Seed the VM's runtime show3D from the persisted setting (3D on by default).
-        GameViewModel(restoredState.state, currentGameStore, initialShow3D = appSettings.board3DEnabled.value)
+        // Seed the VM's runtime show3D + engine difficulty from the persisted settings.
+        GameViewModel(
+            restoredState.state, currentGameStore,
+            initialShow3D = appSettings.board3DEnabled.value,
+            initialEngineDifficulty = appSettings.engineDifficulty.value,
+        )
     }
     val board3D = remember { desktopBoard3DSupport() }
 

--- a/app/src/iosMain/kotlin/com/example/myapplication/MainViewController.kt
+++ b/app/src/iosMain/kotlin/com/example/myapplication/MainViewController.kt
@@ -39,7 +39,11 @@ fun MainViewController(
     val gameHistory = remember { GameHistoryRepository(settings) }
     val pgnSharer = remember { iosPgnSharer() }
     val viewModel = remember {
-        GameViewModel(restoredState.state, currentGameStore, initialShow3D = appSettings.board3DEnabled.value)
+        GameViewModel(
+            restoredState.state, currentGameStore,
+            initialShow3D = appSettings.board3DEnabled.value,
+            initialEngineDifficulty = appSettings.engineDifficulty.value,
+        )
     }
     DisposableEffect(Unit) {
         viewModel.attachEngine(engine)

--- a/app/src/jvmCommonMain/kotlin/com/example/myapplication/BaseStockfishEngine.kt
+++ b/app/src/jvmCommonMain/kotlin/com/example/myapplication/BaseStockfishEngine.kt
@@ -32,6 +32,12 @@ abstract class BaseStockfishEngine : ChessEngine {
     private var readerThread: Thread? = null
     private val lineQueue = LinkedBlockingQueue<String>()
 
+    // Engine difficulty (issue #39 Phase 4). `null` skillLevel = unset; movetime defaults to the
+    // classic think budget. configure() sends `setoption name Skill Level value N` once the engine
+    // process is up; the embedded fallback (no process) ignores skill but still honors movetime.
+    private var skillLevel: Int? = null
+    private var thinkTimeMs: Long = DEFAULT_THINK_TIME_MS
+
     @Volatile
     protected var isReady = false
 
@@ -81,6 +87,10 @@ abstract class BaseStockfishEngine : ChessEngine {
                 return false
             }
 
+            // Apply any difficulty configured before start once the engine is up but before isReady
+            // flips, so the first move uses the configured skill + movetime.
+            skillLevel?.let { sendSkillLevel(it) }
+
             sendCommand("isready")
             if (!waitForLine("readyok", timeoutMs = 5000)) {
                 logger.e { "Engine did not respond with 'readyok'" }
@@ -98,7 +108,23 @@ abstract class BaseStockfishEngine : ChessEngine {
         }
     }
 
-    override suspend fun getBestMove(fen: String): String? = withContext(Dispatchers.IO) { getBestMove(fen, DEFAULT_THINK_TIME_MS) }
+    /**
+     * Applies [difficulty]'s Stockfish `Skill Level` (sent as `setoption`) and stores its movetime
+     * budget for subsequent `go movetime` calls. Safe to call before [start] (the option is applied
+     * once the engine process is up) or after (sent immediately). The embedded fallback (no process)
+     * ignores the skill level but still honors the movetime.
+     */
+    override suspend fun configure(difficulty: EngineDifficulty) = withContext(Dispatchers.IO) {
+        skillLevel = difficulty.skillLevel
+        thinkTimeMs = difficulty.thinkTimeMs
+        if (process != null && isReady) sendSkillLevel(difficulty.skillLevel)
+    }
+
+    private fun sendSkillLevel(level: Int) {
+        sendCommand("setoption name Skill Level value $level")
+    }
+
+    override suspend fun getBestMove(fen: String): String? = withContext(Dispatchers.IO) { getBestMove(fen, thinkTimeMs) }
 
     fun getBestMove(fen: String, thinkTimeMs: Long): String? {
         if (!isReady || process == null) return getEmbeddedBestMove(fen)

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/Main.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/Main.kt
@@ -30,7 +30,11 @@ fun main() {
         val gameHistory = remember { GameHistoryRepository(settings) }
         val pgnSharer = remember { wasmPgnSharer() }
         val viewModel = remember {
-            GameViewModel(restoredState.state, currentGameStore, initialShow3D = appSettings.board3DEnabled.value)
+            GameViewModel(
+                restoredState.state, currentGameStore,
+                initialShow3D = appSettings.board3DEnabled.value,
+                initialEngineDifficulty = appSettings.engineDifficulty.value,
+            )
         }
         LaunchedEffect(Unit) {
             val engine = WasmStockfishEngine()

--- a/app/src/wasmJsMain/kotlin/com/example/myapplication/WasmStockfishEngine.kt
+++ b/app/src/wasmJsMain/kotlin/com/example/myapplication/WasmStockfishEngine.kt
@@ -15,5 +15,7 @@ class WasmStockfishEngine(
 
     override suspend fun evaluate(fen: String): Int? = client.evaluate(fen)
 
+    override suspend fun configure(difficulty: EngineDifficulty) = client.configure(difficulty)
+
     override fun close() = client.close()
 }

--- a/iosApp/iosApp/StockfishChessEngine.swift
+++ b/iosApp/iosApp/StockfishChessEngine.swift
@@ -25,7 +25,7 @@ func waitForSearchCompletion(
 
 private final class SharedStockfishCore {
     static let shared = SharedStockfishCore()
-    
+
     let engine = Engine(type: .stockfish)
     let requestLock = NSLock()
     let stateQueue = DispatchQueue(label: "stockfish.adapter.state")
@@ -33,7 +33,12 @@ private final class SharedStockfishCore {
     var isReady = false
     var pendingCompletion: ((String?) -> Void)?
     var lastRawScoreCp: Int32?
-    
+    // Engine difficulty (issue #39 Phase 4). Defaults to full-strength Stockfish; configure() lowers
+    // the Skill Level + the per-move movetime. Accessed under requestLock (runSearch) so plain vars.
+    var skillLevel: Int? = nil
+    var moveTimeMs: Int = sharedMoveTimeMs
+    var evalMoveTimeMs: Int = sharedEvalMoveTimeMs
+
     private init() {
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self, let stream = await self.engine.responseStream else { return }
@@ -44,6 +49,10 @@ private final class SharedStockfishCore {
                 }
                 if let small = Bundle.main.url(forResource: "nn-37f18f62d772", withExtension: "nnue") {
                     await self.engine.send(command: .setoption(id: "EvalFileSmall", value: small.path))
+                }
+                // Apply any difficulty configured before the engine came up.
+                if let level = self.stateQueue.sync(execute: { self.skillLevel }) {
+                    await self.engine.send(command: .setoption(id: "Skill Level", value: String(level)))
                 }
                 await self.engine.send(command: .isready)
             }
@@ -97,7 +106,11 @@ private final class SharedStockfishCore {
             lastRawScoreCp = nil
             pendingCompletion = { move in bestMove = move; done.signal() }
         }
+        // Engine difficulty (issue #39 Phase 4): re-assert the Skill Level before each search so a
+        // configure() mid-session takes effect on the next move. Mirrors the EvalFile setoption sends.
+        let level = stateQueue.sync { skillLevel }
         Task { [engine] in
+            if let level { await engine.send(command: .setoption(id: "Skill Level", value: String(level))) }
             await engine.send(command: .position(.fen(fen)))
             await engine.send(command: go)
         }
@@ -136,16 +149,17 @@ final class StockfishChessEngine: NSObject, ChessEngine {
         // async response pipeline isn't fully primed yet, so the bestmove response is missed and
         // runSearch returns nil after the full timeout. A single retry reliably produces a move
         // because by the second attempt the pipeline is warmed up.
+        let moveTimeMs = SharedStockfishCore.shared.stateQueue.sync { SharedStockfishCore.shared.moveTimeMs }
         var move = SharedStockfishCore.shared.runSearch(
             fen: fen,
-            go: .go(movetime: sharedMoveTimeMs),
+            go: .go(movetime: moveTimeMs),
             timeout: sharedBestMoveResponseTimeout,
             checkClosed: checkClosed
         )
         if move == nil && !checkClosed() {
             move = SharedStockfishCore.shared.runSearch(
                 fen: fen,
-                go: .go(movetime: sharedMoveTimeMs),
+                go: .go(movetime: moveTimeMs),
                 timeout: sharedBestMoveResponseTimeout,
                 checkClosed: checkClosed
             )
@@ -159,10 +173,11 @@ final class StockfishChessEngine: NSObject, ChessEngine {
         // Like getBestMove, a search on a cold/contended CI pipeline can have its bestmove
         // response missed, so runSearch times out and returns nil (leaving lastRawScoreCp nil).
         // Retry once: the second attempt runs against a warmed-up pipeline and reliably scores.
+        let evalMoveTimeMs = SharedStockfishCore.shared.stateQueue.sync { SharedStockfishCore.shared.evalMoveTimeMs }
         func attempt() -> KotlinInt? {
             guard SharedStockfishCore.shared.runSearch(
                 fen: fen,
-                go: .go(movetime: sharedEvalMoveTimeMs),
+                go: .go(movetime: evalMoveTimeMs),
                 timeout: sharedEvalResponseTimeout,
                 checkClosed: checkClosed
             ) != nil else { return nil }
@@ -179,6 +194,20 @@ final class StockfishChessEngine: NSObject, ChessEngine {
             result = attempt()
         }
         completionHandler(result, nil)
+    }
+
+    /// Engine difficulty (issue #39 Phase 4). Conformance to the Kotlin `ChessEngine.configure`.
+    /// Stores the skill level + movetime on the shared core; runSearch re-asserts the Skill Level
+    /// before the next `go`, and getBestMove/evaluate use the configured movetime. Additive only.
+    func configure(difficulty: EngineDifficulty, completionHandler: @escaping (Error?) -> Void) {
+        SharedStockfishCore.shared.stateQueue.sync {
+            SharedStockfishCore.shared.skillLevel = difficulty.skillLevel.intValue
+            SharedStockfishCore.shared.moveTimeMs = difficulty.thinkTimeMs.intValue
+            // Keep the eval movetime proportional to the play movetime (eval uses 2x the play budget
+            // in the defaults), so weaker difficulty also evaluates faster.
+            SharedStockfishCore.shared.evalMoveTimeMs = max(difficulty.thinkTimeMs.intValue * 2, 200)
+        }
+        completionHandler(nil)
     }
 
     func close() {

--- a/iosApp/iosApp/StockfishChessEngine.swift
+++ b/iosApp/iosApp/StockfishChessEngine.swift
@@ -201,11 +201,11 @@ final class StockfishChessEngine: NSObject, ChessEngine {
     /// before the next `go`, and getBestMove/evaluate use the configured movetime. Additive only.
     func configure(difficulty: EngineDifficulty, completionHandler: @escaping (Error?) -> Void) {
         SharedStockfishCore.shared.stateQueue.sync {
-            SharedStockfishCore.shared.skillLevel = difficulty.skillLevel.intValue
-            SharedStockfishCore.shared.moveTimeMs = difficulty.thinkTimeMs.intValue
+            SharedStockfishCore.shared.skillLevel = Int(difficulty.skillLevel)
+            SharedStockfishCore.shared.moveTimeMs = Int(difficulty.thinkTimeMs)
             // Keep the eval movetime proportional to the play movetime (eval uses 2x the play budget
             // in the defaults), so weaker difficulty also evaluates faster.
-            SharedStockfishCore.shared.evalMoveTimeMs = max(difficulty.thinkTimeMs.intValue * 2, 200)
+            SharedStockfishCore.shared.evalMoveTimeMs = max(Int(difficulty.thinkTimeMs) * 2, 200)
         }
         completionHandler(nil)
     }


### PR DESCRIPTION
Phase 4 of the `docs/plans/issue-39-game-lifecycle-persistence.md` plan — a persisted difficulty setting (Easy/Medium/Hard/Max) that actually weakens/strengthens Stockfish play via `setoption name Skill Level` + a per-move `movetime` budget.

**This is the final in-scope phase of issue #39.** With #56 (Phases 0–1), #64 (Phase 2), #65 (Phase 3), #66 (scope reduction), #67 (3D-toggle move), #68 (CI), and this PR (Phase 4), the full game-lifecycle story is implemented. Phase 5 (time-control) was removed from scope by maintainer decision.

**Resolves #39.**

---

**All engine edits are strictly additive** (per the plan's fence warning): a new defaulted interface method + `setoption`/movetime handling in the *shared* UCI paths + a 2-line Swift send. No rewrites or merges of the platform bridges; the android/desktop `resolveExecutablePath()` subclasses are untouched.

## What landed

### Model + setting (`commonMain`)
- **`EngineDifficulty`** enum (`EASY/MEDIUM/HARD/MAX`) → `skillLevel` (Stockfish `Skill Level` 0–20) + `thinkTimeMs` (per-move `movetime` budget).
- **`AppSettings.engineDifficulty`** — persisted `StateFlow` + `setEngineDifficulty()`, under `settings.engine_difficulty`, default `MEDIUM`.

### Additive `ChessEngine` API (`commonMain`)
New defaulted, non-breaking method: `suspend fun configure(difficulty: EngineDifficulty) {}` — the CPU fallback (no `ChessEngine`) ignores it.

### Shared UCI impls (additive)
- **`UciProtocolClient`** (wasm) — `configure()` stores skill+movetime, sends `setoption name Skill Level value N` (+ `isready` sync); `bestMove` uses the configured movetime.
- **`BaseStockfishEngine`** (jvmCommon → Android+desktop) — same; `getBestMove` uses the configured movetime. The `StockfishEngine`/`DesktopStockfishEngine` subclasses are **untouched**.
- **`WasmStockfishEngine`** — delegates `configure` to its `UciProtocolClient`.

### iOS Swift bridge (the one fence-crossing edit — additive only)
`SharedStockfishCore` stores skill+movetime; `runSearch` re-asserts `setoption name "Skill Level"` before each `go` (mirroring the existing `EvalFile` sends); `getBestMove`/`evaluate` use the configured movetime. `configure(difficulty:completionHandler:)` is the Kotlin-protocol conformance. No restructuring of the semaphore bridge.

### Apply difficulty (VM + entry points + AppRoot)
- **`GameViewModel`** — `initialEngineDifficulty` ctor param + `setEngineDifficulty()`; `attachEngine` applies it on attach.
- **`AppRoot`** — a `LaunchedEffect` collects `appSettings.engineDifficulty` and forwards to `viewModel.setEngineDifficulty`, so SettingsScreen changes flow through.
- All four entry points seed the VM from `AppSettings.engineDifficulty.value`.

### UI (`SettingsScreen`)
4-way difficulty radio group (Easy/Medium/Hard/Max), always visible (difficulty applies to every platform). `testTag("settings_difficulty_<LEVEL>")`.

## Tests
- **`UciProtocolClientTest`** (`commonTest`) — `configure(EASY)` emits `setoption name Skill Level value 2`; subsequent `bestMove` uses `go movetime 200`.
- **`AppSettingsTest`** (`commonTest`) — defaults to MEDIUM; round-trips; unknown stored value falls back to MEDIUM; updates the StateFlow.
- **`EngineDifficultySettingsTest`** (`androidDeviceTest`) — tapping HARD in Settings persists it (behavioural strength not asserted — too flaky).

## Verification
- `./gradlew :app:check` ✅ — Android host/target + wasm tests + iOS test compile (incl. the new tests).
- Full CI gate ✅ — `:androidApp:assembleDebug`, `:app:desktopJar`, `:app:packageDistributionForCurrentOS`, `:app:wasmJsBrowserDistribution`, `:app:assembleAndroidDeviceTest`.

The Swift `configure` path is exercised by CI's `apple-xcode` job (`xcodebuild test` builds + links the Kotlin framework with the Swift conformance).

---

## 🧪 Manual testing — full issue #39 UI entry points

Run on at least desktop + web + Android (iOS where possible). All settings persist across restarts.

### 1. Settings & navigation (Phases 0, 3, 4)
- **Open Settings:** tap **"Settings"** (top-right of the game screen). A radio group for **Engine difficulty** (Easy/Medium/Hard/Max) and — when a 3D backend is present — a **3D board** switch appear.
- **Back:** tap **"Back"** or press Esc / system back → returns to the game.
- **History entry:** tap **"History"** (top-right, next to Settings) → opens the saved-games list.

### 2. Engine difficulty (Phase 4)
- In **Settings**, select **Easy** → close settings → play a few moves; Black (Stockfish) should reply quickly and play noticeably weaker.
- Select **Max** → Black thinks longer (up to the 2s budget) and plays stronger.
- **Persist check:** change to **Hard**, kill & relaunch the app → Settings still shows **Hard**.

### 3. 3D board toggle (PR #67)
- In **Settings**, flip the **3D board** switch off → the game shows the 2D board; flip on → 3D returns (with a brief "Loading 3D Engine" overlay on mount / "Tearing down" on unmount).
- **Persist + default:** fresh install defaults to 3D **on**; toggle off, relaunch → still 2D.

### 4. Autosave + resume-later (Phase 2)
- Start a game, play 3–4 moves, then **kill the app** (swipe-away / close window / reload the page).
- Relaunch → the game **resumes** on the exact board, side-to-move, and move count you left it on.
- If it was Black's turn when killed, the engine resumes and moves.
- A game that was **already over** when killed starts **fresh** (the autosave is cleared).

### 5. Game history + Save + Share (Phase 3)
- Finish a game (checkmate / stalemate / draw). The game-over popup shows **Save game** and **Share PGN** buttons (next to Play again / Cancel).
- **Save game:** tap it → button changes to **"Saved"** (double-save guarded). Open **History** → one row with the right result (e.g. `1-0`), players, and move count.
- **History detail:** tap a row → full PGN text (selectable) + **Share** + **Delete**.
- **Share PGN:** tap Share in the popup or the detail view → platform share sheet / save dialog / browser download fires with the PGN. **Validate the PGN:** paste it into https://lichess.org → "Tools" → "Import game" — it should load the exact game with correct SAN.
- **Delete:** in History, tap **Delete** → row removed; empty state shows.