### PR TITLE
[codex] fix settings 3D board remount

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,9 @@ tools/fetch_filament_desktop.sh                 # fetch gitignored desktop Filam
 tools/ios_3d_screenshot.sh                      # screenshot the real iOS 3D board in a booted sim -> build/ios-3d-screenshot.png
 ```
 
+When an Android SDK path is needed, use the Android CLI first: `android info sdk`.
+On this machine it currently reports `/Users/presence/Library/Android/sdk`; prefer the CLI result over guessing or hard-coding `ANDROID_HOME`.
+
 Verifying the iOS Filament/Metal 3D *look* can't be done from a unit test — the Metal-backed `UIKitView` needs the real app/simulator rendering stack, which the headless `simctl spawn` Kotlin/Native test runner cannot provide. Use `tools/ios_3d_screenshot.sh` instead: it launches the real app with `CHESS_START_3D=1` (read in `MainViewController`) so it opens directly on the 3D board, then captures via `simctl io screenshot`.
 
 CI (`.github/workflows/android-tests.yml`) builds every target with:

--- a/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/AppRoot.kt
@@ -102,6 +102,7 @@ internal fun SubScreenScaffold(
     title: String,
     onBack: () -> Unit,
     scrollable: Boolean = true,
+    showBackButton: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     Scaffold(
@@ -109,8 +110,10 @@ internal fun SubScreenScaffold(
             TopAppBar(
                 title = { Text(title) },
                 navigationIcon = {
-                    Button(onClick = onBack, modifier = Modifier.padding(start = 8.dp)) {
-                        Text("Back")
+                    if (showBackButton) {
+                        Button(onClick = onBack, modifier = Modifier.padding(start = 8.dp)) {
+                            Text("Back")
+                        }
                     }
                 }
             )

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameScreen.kt
@@ -296,6 +296,7 @@ fun GameScreen(
             // synchronously on the UI thread during composition; composing it in the same frame as
             // the loader leaves the spinner no frame to draw. Hold it back two frames.
             var surfaceComposeReady by remember { mutableStateOf(false) }
+            var rendererReady by remember { mutableStateOf(false) }
             LaunchedEffect(Unit) {
                 withFrameNanos { }
                 withFrameNanos { }
@@ -309,10 +310,14 @@ fun GameScreen(
                     modifier = Modifier.fillMaxSize(),
                     onUnavailable = {
                         isEntering3D = false
+                        rendererReady = true
                         viewModel.markBoard3DUnavailable()
                     },
                     cameraSession = board3DCameraSession,
-                    onRendererReady = { isEntering3D = false },
+                    onRendererReady = {
+                        isEntering3D = false
+                        rendererReady = true
+                    },
                     selectedSquare = gameState.selectedSquare
                         .takeIf { it != INVALID_POSITION }
                         ?.let { BoardSquare(it.first, it.second) },
@@ -340,7 +345,7 @@ fun GameScreen(
                 )
                 }
 
-                if (isEntering3D || !surfaceComposeReady) {
+                if (isEntering3D || !surfaceComposeReady || !rendererReady) {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()

--- a/app/src/commonMain/kotlin/com/example/myapplication/SettingsScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/SettingsScreen.kt
@@ -48,7 +48,7 @@ fun SettingsScreen(
     val board3DEnabled by settings.board3DEnabled.collectAsState()
     val engineDifficulty by settings.engineDifficulty.collectAsState()
 
-    SubScreenScaffold(title = "Settings", onBack = onBack) {
+    SubScreenScaffold(title = "Settings", onBack = onBack, showBackButton = false) {
         Text(
             text = "Engine difficulty",
             style = MaterialTheme.typography.titleMedium,

--- a/app/src/desktopTest/kotlin/com/example/myapplication/SettingsScreenUiTest.kt
+++ b/app/src/desktopTest/kotlin/com/example/myapplication/SettingsScreenUiTest.kt
@@ -1,0 +1,32 @@
+package com.example.myapplication
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.runComposeUiTest
+import com.example.myapplication.persistence.AppSettings
+import com.example.myapplication.persistence.LocalAppSettings
+import com.example.myapplication.persistence.MapSettings
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class SettingsScreenUiTest {
+
+    @Test
+    fun settingsScreenDoesNotShowAVisibleBackButton() = runComposeUiTest {
+        val appSettings = AppSettings(MapSettings())
+
+        setContent {
+            CompositionLocalProvider(LocalAppSettings provides appSettings) {
+                SettingsScreen(onBack = {})
+            }
+        }
+        waitForIdle()
+
+        assertTrue(
+            onAllNodesWithText("Back").fetchSemanticsNodes().isEmpty(),
+            "Settings is dismissed by system back/swipe, so it should not render its own Back button"
+        )
+    }
+}

--- a/app/src/desktopTest/kotlin/com/example/myapplication/board3d/Board3DUiTest.kt
+++ b/app/src/desktopTest/kotlin/com/example/myapplication/board3d/Board3DUiTest.kt
@@ -2,15 +2,20 @@ package com.example.myapplication.board3d
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.runComposeUiTest
 import com.example.myapplication.GameScreen
 import com.example.myapplication.GameViewModel
+import com.example.myapplication.SettingsScreen
 import com.example.myapplication.WindowWidthSizeClass
 import com.example.myapplication.persistence.AppSettings
 import com.example.myapplication.persistence.LocalAppSettings
 import com.example.myapplication.persistence.MapSettings
+import kotlinx.coroutines.CompletableDeferred
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -116,6 +121,62 @@ class Board3DUiTest {
     }
 
     @Test
+    fun remounting3DFromSettingsKeepsEnteringOverlayUntilRendererReady() = runComposeUiTest {
+        val firstRenderer = FakeChess3DRenderer()
+        val secondRenderer = FakeChess3DRenderer()
+        val secondRendererReady = CompletableDeferred<Chess3DBoardRenderer?>()
+        var createCount = 0
+        val support = Board3DSupport(
+            rendererFactory = {
+                createCount += 1
+                if (createCount == 1) firstRenderer else secondRendererReady.await()
+            },
+            surfaceContent = { r, modifier ->
+                androidx.compose.runtime.DisposableEffect(r) {
+                    r.attach(FakeChess3DSurface())
+                    onDispose { r.detach() }
+                }
+                Box(modifier)
+            },
+        )
+        val viewModel = GameViewModel()
+        val appSettings = AppSettings(MapSettings())
+        var showingSettings by mutableStateOf(false)
+
+        setContent {
+            CompositionLocalProvider(LocalAppSettings provides appSettings) {
+                if (showingSettings) {
+                    SettingsScreen(onBack = {}, board3D = support)
+                } else {
+                    GameScreen(WindowWidthSizeClass.Medium, viewModel, support)
+                }
+            }
+        }
+        waitForIdle()
+        assertTrue(onAllNodesWithTag("board_3d").fetchSemanticsNodes().isNotEmpty())
+
+        runOnIdle { showingSettings = true }
+        waitForIdle()
+        assertEquals(1, firstRenderer.events.count { it == "dispose" })
+
+        mainClock.autoAdvance = false
+        runOnIdle { showingSettings = false }
+        mainClock.advanceTimeByFrame()
+        mainClock.advanceTimeByFrame()
+        mainClock.advanceTimeByFrame()
+
+        assertTrue(
+            onAllNodesWithTag("board_3d_entering").fetchSemanticsNodes().isNotEmpty(),
+            "Expected the opaque 3D entering overlay to remain visible while the remounted renderer is still pending"
+        )
+
+        secondRendererReady.complete(secondRenderer)
+        mainClock.autoAdvance = true
+        waitForIdle()
+        assertTrue(onAllNodesWithTag("board_3d").fetchSemanticsNodes().isNotEmpty())
+    }
+
+    @Test
     fun test3DFallbackWhenFactoryReturnsNull() = runComposeUiTest {
         val board3DSupport = Board3DSupport(
             rendererFactory = { null }, // init fails
@@ -168,4 +229,3 @@ class Board3DUiTest {
         assertTrue(animationEvents.isNotEmpty(), "Expected at least one animated updatePosition event")
     }
 }
-


### PR DESCRIPTION
## Summary

- Remove the visible Back button from the Settings screen while keeping system back/swipe navigation through AppRoot.
- Keep the opaque 3D loading overlay visible on every 3D board mount until the renderer reports ready, including when returning from Settings with 3D already enabled.
- Add desktop fake-renderer UI regression tests for the Settings back button and Settings -> 3D remount path.
- Document that Android SDK discovery should use android info sdk first.

## Root Cause

Returning from Settings remounts GameScreen while viewState.show3D can already be true. The previous entry overlay was only set when the persisted 3D setting flipped, so the remounted 3D surface could show an unprotected initializing frame instead of the loading overlay.

## Validation

- git diff --cached --check
- ./gradlew :app:desktopTest --tests com.example.myapplication.board3d.Board3DUiTest --tests com.example.myapplication.SettingsScreenUiTest -x configureDesktopFilamentBridge -x buildDesktopFilamentBridge -x syncDesktopFilamentBridgeResources
- ./gradlew :app:compileKotlinWasmJs
- env ANDROID_HOME=/Users/presence/Library/Android/sdk ./gradlew :app:compileAndroidDeviceTest

Note: the desktop UI regression suite above uses fake renderers and skips the native desktop Filament bridge tasks because this worktree does not include the gitignored desktop Filament payload.