### PR TITLE
Fix reset game ignoring 3D settings board mode

### DIFF
--- a/app/src/commonMain/kotlin/com/example/myapplication/GameScreen.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameScreen.kt
@@ -192,7 +192,7 @@ fun GameScreen(
             var gameSaved by remember(gameState.winState, gameState.fullmoveNumber) { mutableStateOf(false) }
             val resetGame = { reset: Boolean ->
                 if (reset) {
-                    viewModel.resetGame()
+                    viewModel.resetGame(show3D = board3DEnabled)
                 } else {
                     viewModel.hideWindow()
                 }
@@ -376,6 +376,7 @@ fun GameScreen(
                 animState = animState,
                 viewState = viewState,
                 viewModel = viewModel,
+                onResetGame = { viewModel.resetGame(show3D = board3DEnabled) },
                 transparentButtons = true,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -413,7 +414,8 @@ fun GameScreen(
                         gameState = gameState,
                         animState = animState,
                         viewState = viewState,
-                        viewModel = viewModel
+                        viewModel = viewModel,
+                        onResetGame = { viewModel.resetGame(show3D = board3DEnabled) }
                     )
                 }
             }
@@ -460,6 +462,7 @@ private fun GameControls(
     animState: PieceAnimationState,
     viewState: ViewState,
     viewModel: GameViewModel,
+    onResetGame: () -> Unit,
     transparentButtons: Boolean = false,
     modifier: Modifier = Modifier
 ) {
@@ -477,7 +480,7 @@ private fun GameControls(
 
         Row {
             if (transparentButtons) {
-                TransparentUnderlineButton(onClick = viewModel::resetGame) {
+                TransparentUnderlineButton(onClick = onResetGame) {
                     Text(stringResource(Res.string.reset_button))
                 }
                 TransparentUnderlineButton(
@@ -486,7 +489,7 @@ private fun GameControls(
                     modifier = Modifier.testTag("offer_draw_button")
                 ) { Text(stringResource(Res.string.offer_draw_button)) }
             } else {
-                Button(onClick = viewModel::resetGame) {
+                Button(onClick = onResetGame) {
                     Text(stringResource(Res.string.reset_button))
                 }
                 Button(

--- a/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
+++ b/app/src/commonMain/kotlin/com/example/myapplication/GameViewModel.kt
@@ -288,10 +288,10 @@ class GameViewModel(
         }
     }
 
-    fun resetGame() {
+    fun resetGame(show3D: Boolean = viewState.value.show3D) {
         logger.i { "Game reset" }
         _gameState.value = GameUiState()
-        _viewState.value = ViewState()
+        _viewState.value = ViewState(show3D = show3D)
         _animState.value = PieceAnimationState()
         // The fresh empty game replaces the autosaved one; drop the stale snapshot so a relaunch
         // doesn't restore into a board the user already abandoned.

--- a/app/src/desktopTest/kotlin/com/example/myapplication/board3d/Board3DUiTest.kt
+++ b/app/src/desktopTest/kotlin/com/example/myapplication/board3d/Board3DUiTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import com.example.myapplication.GameScreen
 import com.example.myapplication.GameViewModel
@@ -118,6 +120,26 @@ class Board3DUiTest {
 
         // Verify renderer was attached again
         assertEquals(2, fakeRenderer.events.count { it == "attach" })
+    }
+
+    @Test
+    fun resetKeepsBoardModeFromSettingsWhen3DIsDisabled() = runComposeUiTest {
+        val fakeRenderer = FakeChess3DRenderer()
+        val viewModel = GameViewModel()
+
+        val appSettings = wrapGame(viewModel, fakeSupport(fakeRenderer))
+        waitForIdle()
+
+        appSettings.setBoard3DEnabled(false)
+        waitForIdle()
+        assertTrue(onAllNodesWithTag("chess_board").fetchSemanticsNodes().isNotEmpty())
+        assertTrue(onAllNodesWithTag("board_3d").fetchSemanticsNodes().isEmpty())
+
+        onNodeWithText("Reset").performClick()
+        waitForIdle()
+
+        assertTrue(onAllNodesWithTag("chess_board").fetchSemanticsNodes().isNotEmpty())
+        assertTrue(onAllNodesWithTag("board_3d").fetchSemanticsNodes().isEmpty())
     }
 
     @Test


### PR DESCRIPTION
when we pressed Reset, if 3D was off in Settings , it did not go to the 2D board but defaulted to 3D